### PR TITLE
cordon exclude filters

### DIFF
--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: planetlabs/draino
-  tag: 2c3d2b4
+  tag: 450a853
   pullPolicy: IfNotPresent
 
 resources:

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -193,19 +193,19 @@ func (d *APICordonDrainer) deleteTimeout() time.Duration {
 
 // Cordon the supplied node. Marks it unschedulable for new pods.
 func (d *APICordonDrainer) Cordon(n *core.Node, mutators ...nodeMutatorFn) error {
+	if d.cordonLimiter != nil {
+		canCordon, reason := d.cordonLimiter.CanCordon(n)
+		if !canCordon {
+			return NewLimiterError(reason)
+		}
+	}
+
 	fresh, err := d.c.CoreV1().Nodes().Get(n.GetName(), meta.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "cannot get node %s", n.GetName())
 	}
 	if fresh.Spec.Unschedulable {
 		return nil
-	}
-
-	if d.cordonLimiter != nil {
-		canCordon, reason := d.cordonLimiter.CanCordon(n)
-		if !canCordon {
-			return NewLimiterError(reason)
-		}
 	}
 
 	fresh.Spec.Unschedulable = true
@@ -308,7 +308,7 @@ func (d *APICordonDrainer) Drain(n *core.Node) error {
 		return nil
 	}
 
-	pods, err := d.getPods(n.GetName())
+	pods, err := d.getPodsToDrain(n.GetName())
 	if err != nil {
 		return errors.Wrapf(err, "cannot get pods for node %s", n.GetName())
 	}
@@ -337,7 +337,7 @@ func (d *APICordonDrainer) Drain(n *core.Node) error {
 	return nil
 }
 
-func (d *APICordonDrainer) getPods(node string) ([]core.Pod, error) {
+func (d *APICordonDrainer) getPodsToDrain(node string) ([]core.Pod, error) {
 	l, err := d.c.CoreV1().Pods(meta.NamespaceAll).List(meta.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node}).String(),
 	})

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -88,6 +88,7 @@ func (f fakeLimiter) SetNodeLister(lister NodeLister)              {}
 func (f fakeLimiter) AddLimiter(s string, limiterFunc LimiterFunc) {}
 
 var _ CordonLimiter = &fakeLimiter{}
+
 func newFakeDynamicClient(objects ...runtime.Object) dynamic.Interface {
 	scheme := runtime.NewScheme()
 	if err := fake.AddToScheme(scheme); err != nil {

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -39,6 +39,7 @@ const (
 	eventReasonCordonBlockedByLimit = "CordonBlockedByLimit"
 	eventReasonCordonSucceeded      = "CordonSucceeded"
 	eventReasonCordonFailed         = "CordonFailed"
+	eventReasonCordonSkip           = "CordonSkip"
 
 	eventReasonUncordonStarting  = "UncordonStarting"
 	eventReasonUncordonSucceeded = "UncordonSucceeded"
@@ -79,6 +80,9 @@ type DrainingResourceEventHandler struct {
 	eventRecorder  record.EventRecorder
 	drainScheduler DrainScheduler
 
+	podStore     PodStore
+	cordonFilter PodFilterFunc
+
 	lastDrainScheduledFor time.Time
 	buffer                time.Duration
 
@@ -107,6 +111,15 @@ func WithDrainBuffer(d time.Duration) DrainingResourceEventHandlerOption {
 func WithConditionsFilter(conditions []string) DrainingResourceEventHandlerOption {
 	return func(h *DrainingResourceEventHandler) {
 		h.conditions = ParseConditions(conditions)
+	}
+}
+
+// WithCordonPodFilter configures a filter that may prevent to cordon nodes
+// to avoid further impossible eviction when draining.
+func WithCordonPodFilter(f PodFilterFunc, podStore PodStore) DrainingResourceEventHandlerOption {
+	return func(d *DrainingResourceEventHandler) {
+		d.cordonFilter = f
+		d.podStore = podStore
 	}
 }
 
@@ -165,9 +178,13 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 		return
 	}
 
-	// First cordon the node if it is not yet cordonned
+	// First cordon the node if it is not yet cordoned
 	if !n.Spec.Unschedulable {
-		if err:= h.cordon(n, badConditions); err!=nil {
+		// check if the node passes filters
+		if !h.checkCordonFilters(n) {
+			return
+		}
+		if err := h.cordon(n, badConditions); err != nil {
 			return
 		}
 	}
@@ -185,6 +202,33 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 		h.scheduleDrain(n)
 		return
 	}
+}
+
+// checkCordonFilters return true if the filtering is ok to proceed
+func (h *DrainingResourceEventHandler) checkCordonFilters(n *core.Node) bool {
+	if h.cordonFilter != nil && h.podStore != nil {
+		pods, err := h.podStore.ListPodsForNode(n.Name)
+		if err != nil {
+			h.logger.Error("cannot retrieve pods for node", zap.Error(err), zap.String("node", n.Name))
+			return false
+		}
+
+		for _, pod := range pods {
+			ok, err := h.cordonFilter(*pod)
+			if err != nil {
+				h.logger.Error("filtering issue", zap.Error(err), zap.String("node", n.Name), zap.String("pod", pod.Name), zap.String("namespace", n.Name))
+				return false
+			}
+			if !ok {
+				nr := &core.ObjectReference{Kind: "Node", Name: n.Name, UID: types.UID(n.Name)}
+				h.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonCordonSkip, "Pod %s/%s is not in eviction scope", pod.Namespace, pod.Name)
+				h.eventRecorder.Eventf(pod, core.EventTypeWarning, eventReasonCordonSkip, "Pod is blocking cordon/drain for node %s", n.Name)
+				h.logger.Info("Cordon filter triggered", zap.String("node", n.Name), zap.String("pod", pod.Name))
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (h *DrainingResourceEventHandler) offendingConditions(n *core.Node) []SuppliedCondition {

--- a/internal/kubernetes/podfilters.go
+++ b/internal/kubernetes/podfilters.go
@@ -51,7 +51,6 @@ func LocalStoragePodFilter(p core.Pod) (bool, error) {
 func NewPodControlledByFilter(client dynamic.Interface, controlledByAPIResources []*meta.APIResource) PodFilterFunc {
 	return func(p core.Pod) (bool, error) {
 		for _, controlledBy := range controlledByAPIResources {
-
 			if controlledBy == nil { //means uncontrolled pod
 				if p.Status.Phase == core.PodSucceeded || p.Status.Phase == core.PodFailed {
 					continue
@@ -111,7 +110,6 @@ func UnprotectedPodFilter(annotations ...string) PodFilterFunc {
 
 // NewPodFilters returns a FilterFunc that returns true if all of the supplied
 // FilterFuncs return true.
-
 func NewPodFilters(filters ...PodFilterFunc) PodFilterFunc {
 	return func(p core.Pod) (bool, error) {
 		for _, fn := range filters {

--- a/internal/kubernetes/util_test.go
+++ b/internal/kubernetes/util_test.go
@@ -67,7 +67,7 @@ var (
 	}
 
 	DaemonSetV1Apps = metav1.APIResource{
-		Name: "daemonsets",
+		Name:         "daemonsets",
 		SingularName: "daemonset",
 		Namespaced:   true,
 		Group:        "apps",
@@ -75,7 +75,7 @@ var (
 		Kind:         "DaemonSet",
 	}
 	StatefulSetSetV1Apps = metav1.APIResource{
-		Name: "statefulsets",
+		Name:         "statefulsets",
 		SingularName: "statefulset",
 		Namespaced:   true,
 		Group:        "apps",
@@ -83,7 +83,7 @@ var (
 		Kind:         "StatefulSet",
 	}
 	StatefulSetSetV1beta2Apps = metav1.APIResource{
-		Name: "statefulsets",
+		Name:         "statefulsets",
 		SingularName: "statefulset",
 		Namespaced:   true,
 		Group:        "apps",
@@ -202,18 +202,18 @@ func TestGetAPIResourcesForGVK(t *testing.T) {
 		{
 			name:    "statefulsets",
 			gvks:    []string{"StatefulSet"},
-			want:    []*metav1.APIResource{&StatefulSetSetV1Apps,&StatefulSetSetV1beta2Apps},
+			want:    []*metav1.APIResource{&StatefulSetSetV1Apps, &StatefulSetSetV1beta2Apps},
 			wantErr: false,
 		},
 		{
 			name:    "all",
-			gvks:    []string{"StatefulSet","DaemonSet","","ExtendedDaemonSet"},
-			want:    []*metav1.APIResource{nil,&StatefulSetSetV1Apps,&StatefulSetSetV1beta2Apps,&DaemonSetV1Apps,&ExtendedDaemonSetV1alpha1Datadog},
+			gvks:    []string{"StatefulSet", "DaemonSet", "", "ExtendedDaemonSet"},
+			want:    []*metav1.APIResource{nil, &StatefulSetSetV1Apps, &StatefulSetSetV1beta2Apps, &DaemonSetV1Apps, &ExtendedDaemonSetV1alpha1Datadog},
 			wantErr: false,
 		},
 		{
 			name:    "error not found",
-			gvks:    []string{"StatefulSet","DaemonSet","","ExtendedDaemonSet","Wrong"},
+			gvks:    []string{"StatefulSet", "DaemonSet", "", "ExtendedDaemonSet", "Wrong"},
 			want:    nil,
 			wantErr: true,
 		},


### PR DESCRIPTION
Code for issue [#94](https://github.com/planetlabs/draino/issues/94)

This will allow us to avoid going to the cordon step if we detect that one of the pods on the node cannot be drained later.