### PR TITLE
Fix concurrency on restart + ensure cordon before drain

### DIFF
--- a/internal/kubernetes/limiter.go
+++ b/internal/kubernetes/limiter.go
@@ -44,7 +44,7 @@ type NodeLister interface {
 func NewCordonLimiter(logger *zap.Logger) CordonLimiter {
 	return &Limiter{
 		logger:      logger,
-		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(2, 2),
+		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),	// limiters are computing % on top of the cache. Here we ensure that the cache has time to be updated.
 	}
 }
 


### PR DESCRIPTION
Fix concurrency issue on cordon activity, and ensure that a node is cordon before scheduling any drain activity