### PR TITLE
delete PVC/PV after eviction for annotated pods

### DIFF
--- a/internal/kubernetes/limiter_test.go
+++ b/internal/kubernetes/limiter_test.go
@@ -7,7 +7,7 @@ import (
 
 	"go.uber.org/zap"
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/flowcontrol"
 )
@@ -385,7 +385,6 @@ func TestParseCordonMaxForKeys(t *testing.T) {
 }
 
 func TestIsLimiterError(t *testing.T) {
-
 	tests := []struct {
 		name string
 		err  error

--- a/internal/kubernetes/nodefilters.go
+++ b/internal/kubernetes/nodefilters.go
@@ -22,17 +22,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/antonmedv/expr"
 	"go.uber.org/zap"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/antonmedv/expr"
 )
 
 // NewNodeLabelFilter returns a filter that returns true if the supplied node satisfies the boolean expression
 func NewNodeLabelFilter(expressionStr *string, log *zap.Logger) (func(o interface{}) bool, error) {
 	//This feels wrong but this is how the previous behavior worked so I'm only keeping it to maintain compatibility.
-
 	expression, err := expr.Compile(*expressionStr)
 	if err != nil && *expressionStr != "" {
 		return nil, err
@@ -50,6 +48,9 @@ func NewNodeLabelFilter(expressionStr *string, log *zap.Logger) (func(o interfac
 		}
 
 		nodeLabels := n.GetLabels()
+
+		//_, ok = nodeLabels["node-role.kubernetes.io/demo-eviction"]
+		//return ok
 
 		parameters := map[string]interface{}{
 			"metadata": map[string]map[string]string{

--- a/internal/kubernetes/nodefilters_test.go
+++ b/internal/kubernetes/nodefilters_test.go
@@ -85,6 +85,21 @@ func TestNodeLabelFilter(t *testing.T) {
 			passesFilter: true,
 		},
 		{
+			name: "Exclusion on match",
+			obj: &core.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						"region": "us-west-2",
+						"app":    "nginx",
+						"type":   "sup-xyz",
+					},
+				},
+			},
+			expression:   "metadata.labels['region'] == 'us-west-2' && metadata.labels['app'] == 'nginx' && not ( metadata.labels['type'] matches 'sup-x.+')",
+			passesFilter: false,
+		},
+		{
 			name: "PR75Example2",
 			obj: &core.Node{
 				ObjectMeta: meta.ObjectMeta{

--- a/internal/kubernetes/podfilters.go
+++ b/internal/kubernetes/podfilters.go
@@ -68,16 +68,16 @@ func NewPodControlledByFilter(client dynamic.Interface, controlledByAPIResources
 
 			if _, err := client.Resource(schema.GroupVersionResource{Group: controlledBy.Group, Version: controlledBy.Version, Resource: controlledBy.Name}).Namespace(p.Namespace).Get(c.Name, meta.GetOptions{}); err != nil {
 				if apierrors.IsNotFound(err) {
+					// the controller was deleted, so the pod can be deleted/evicted also.
 					continue
 				}
 				return false, errors.Wrapf(err, "cannot get pod %s/%s controlled by %s", p.GetNamespace(), c.Name, controlledBy)
-			} else {
-				return false, nil
 			}
+			// the pod is still under control, so we protect the pod from eviction
+			return false, nil
 		}
 		return true, nil
 	}
-
 }
 
 // UnprotectedPodFilter returns a FilterFunc that returns true if the

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -70,7 +70,7 @@ func RetryWithTimeout(f func() error, retryPeriod, timeout time.Duration) error 
 func GetAPIResources(discoveryClient discovery.DiscoveryInterface) ([]metav1.APIResource, error) {
 	groupList, err := discoveryClient.ServerGroups()
 	if groupList == nil || err != nil || groupList.Groups == nil {
-		return nil, fmt.Errorf("Fail to discover groups")
+		return nil, fmt.Errorf("failed to discover groups")
 	}
 
 	var allServerResources []metav1.APIResource
@@ -103,9 +103,8 @@ func GetAPIResources(discoveryClient discovery.DiscoveryInterface) ([]metav1.API
 func GetAPIResourcesForGroupsKindVersion(apiResources []metav1.APIResource, gvks []string) ([]metav1.APIResource, error) {
 	var outputAPIResources []metav1.APIResource
 	for _, gvkInput := range gvks {
-
 		if gvkInput == "" {
-			return nil, fmt.Errorf("Empty GroupVersionKind value")
+			return nil, fmt.Errorf("empty GroupVersionKind value")
 		}
 
 		atLeastOneResourceFound := false
@@ -134,7 +133,7 @@ func GetAPIResourcesForGroupsKindVersion(apiResources []metav1.APIResource, gvks
 		}
 
 		if !atLeastOneResourceFound {
-			return nil, fmt.Errorf("Could not find any APIResource matching kind[.version[.group]]='%s'", gvkInput)
+			return nil, fmt.Errorf("could not find any APIResource matching kind[.version[.group]]='%s'", gvkInput)
 		}
 	}
 	return outputAPIResources, nil
@@ -143,7 +142,7 @@ func GetAPIResourcesForGroupsKindVersion(apiResources []metav1.APIResource, gvks
 // GetAPIResourcesForGVK retrieves the apiResources that match the given 'Kind.Version.Group'
 // taking into account the empty case that associate a nil value in the list (used for uncontrolled pod filtering)
 // and filtering out subresources
-func GetAPIResourcesForGVK(discovery discovery.DiscoveryInterface, gvks []string) ([]*metav1.APIResource, error) {
+func GetAPIResourcesForGVK(discoveryInterface discovery.DiscoveryInterface, gvks []string) ([]*metav1.APIResource, error) {
 	hasEmptyGVK := false
 	var nonEmptyGVKs []string
 	for _, v := range gvks {
@@ -154,7 +153,7 @@ func GetAPIResourcesForGVK(discovery discovery.DiscoveryInterface, gvks []string
 		nonEmptyGVKs = append(nonEmptyGVKs, v)
 	}
 
-	allAPIResources, err := GetAPIResources(discovery)
+	allAPIResources, err := GetAPIResources(discoveryInterface)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR allows Draino to take care of PVC/PV in case a statefulset pods is annotated (opt-in) for that feature.
So far the annotation specify the storage class for which we want to do this cleanup. I will open discussion with users to understand if this a good idea to given them control on that, or if they prefer this to be 100% driven by draino (storage class configured inside draino).

This PR also has some linting of existing code.
