### PR TITLE
David.benque/issue 107

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -58,7 +58,7 @@ func main() {
 		maxGracePeriod   = app.Flag("max-grace-period", "Maximum time evicted pods will be given to terminate gracefully.").Default(kubernetes.DefaultMaxGracePeriod.String()).Duration()
 		evictionHeadroom = app.Flag("eviction-headroom", "Additional time to wait after a pod's termination grace period for it to have been deleted.").Default(kubernetes.DefaultEvictionOverhead.String()).Duration()
 		drainBuffer      = app.Flag("drain-buffer", "Minimum time between starting each drain. Nodes are always cordoned immediately.").Default(kubernetes.DefaultDrainBuffer.String()).Duration()
-		nodeLabels       = app.Flag("node-label", "(Deprecated) Nodes with this label will be eligible for cordoning and draining. May be specified multiple times").StringMap()
+		nodeLabels       = app.Flag("node-label", "(Deprecated) Nodes with this label will be eligible for cordoning and draining. May be specified multiple times").Strings()
 		nodeLabelsExpr   = app.Flag("node-label-expr", "Nodes that match this expression will be eligible for cordoning and draining.").String()
 		namespace        = app.Flag("namespace", "Namespace used to create leader election lock object.").Default("kube-system").String()
 
@@ -188,8 +188,9 @@ func main() {
 		if *nodeLabelsExpr != "" {
 			kingpin.Fatalf("nodeLabels and NodeLabelsExpr cannot both be set")
 		}
-
-		nodeLabelsExpr = kubernetes.ConvertLabelsToFilterExpr(*nodeLabels)
+		if nodeLabelsExpr, err = kubernetes.ConvertLabelsToFilterExpr(*nodeLabels); err != nil {
+			kingpin.Fatalf(err.Error())
+		}
 	}
 
 	var nodeLabelFilter cache.ResourceEventHandler

--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: planetlabs/draino
-  tag: 2c3d2b4
+  tag: 450a853
   pullPolicy: IfNotPresent
 
 resources:

--- a/internal/kubernetes/nodefilters.go
+++ b/internal/kubernetes/nodefilters.go
@@ -108,9 +108,18 @@ func (processed NodeProcessed) Filter(o interface{}) bool {
 }
 
 // ConvertLabelsToFilterExpr Convert old list labels into new expression syntax
-func ConvertLabelsToFilterExpr(labels map[string]string) *string {
+func ConvertLabelsToFilterExpr(labelsSlice []string) (*string, error) {
+	labels := map[string]string{}
+	for _, label := range labelsSlice {
+		tokens := strings.SplitN(label, "=", 2)
+		key := tokens[0]
+		value := tokens[1]
+		if v, found := labels[key]; found && v != value {
+			return nil, fmt.Errorf("node-label parameter is used twice with the same key and different values: '%s' , '%s", v, value)
+		}
+		labels[key] = value
+	}
 	res := []string{}
-
 	//sort the maps so that the unit tests actually work
 	keys := make([]string, 0, len(labels))
 	for k := range labels {
@@ -126,5 +135,5 @@ func ConvertLabelsToFilterExpr(labels map[string]string) *string {
 		}
 	}
 	temp := strings.Join(res, " && ")
-	return &temp
+	return &temp, nil
 }

--- a/internal/kubernetes/nodefilters.go
+++ b/internal/kubernetes/nodefilters.go
@@ -122,7 +122,7 @@ func ConvertLabelsToFilterExpr(labels map[string]string) *string {
 		if k != "" && labels[k] == "" {
 			res = append(res, fmt.Sprintf(`'%s' in metadata.labels`, k))
 		} else {
-			res = append(res, fmt.Sprintf(`metadata.labels.%s == '%s'`, k, labels[k]))
+			res = append(res, fmt.Sprintf(`metadata.labels['%s'] == '%s'`, k, labels[k]))
 		}
 	}
 	temp := strings.Join(res, " && ")

--- a/internal/kubernetes/nodefilters_test.go
+++ b/internal/kubernetes/nodefilters_test.go
@@ -235,6 +235,17 @@ func TestOldNodeLabelFilter(t *testing.T) {
 			passesFilter: true,
 		},
 		{
+			name: "SingleMatchingLabel.WithDomain",
+			obj: &core.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{"planetlabs.com/cool": "very"},
+				},
+			},
+			labels:       map[string]string{"planetlabs.com/cool": "very"},
+			passesFilter: true,
+		},
+		{
 			name: "ManyMatchingLabels",
 			obj: &core.Node{
 				ObjectMeta: meta.ObjectMeta{
@@ -431,7 +442,7 @@ func TestConvertLabelsToFilterExpr(t *testing.T) {
 		"sup": "cool",
 	}
 
-	desired := "metadata.labels.foo == 'bar' && metadata.labels.sup == 'cool'"
+	desired := "metadata.labels['foo'] == 'bar' && metadata.labels['sup'] == 'cool'"
 	actual := ConvertLabelsToFilterExpr(input)
 
 	assert.Equal(t, desired, *actual)


### PR DESCRIPTION
Fix # 107 upstream issue
There are 2 ways of filtering nodes that are in scope. If using `node-label`, an AND operator is applied (to keep historic behavior).
The problem is that if the user provide the parameter twice with the same Key and different value, only one of the 2 value is taken into account. Somehow the program is silently failing: it is not doing a AND that would result in an empty intersection, it would use one of the 2 values.