### PR TITLE
pod filter for storage class

### DIFF
--- a/internal/kubernetes/podfilters.go
+++ b/internal/kubernetes/podfilters.go
@@ -25,6 +25,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
 
 // A PodFilterFunc returns true if the supplied pod passes the filter.
@@ -78,6 +79,37 @@ func NewPodControlledByFilter(client dynamic.Interface, controlledByAPIResources
 		return true, nil
 	}
 
+}
+
+// NewPodUsingStorageClassFilter returns a FilterFunc that returns false if the supplied
+// pod is using one of the given storage class
+func NewPodUsingStorageClassFilter(client kubernetes.Interface, storageClasses []string) PodFilterFunc {
+	storageClassesSet := map[string]struct{}{}
+	for _, sc := range storageClasses {
+		storageClassesSet[sc] = struct{}{}
+	}
+	return func(pod core.Pod) (bool, error) {
+		for _, v := range pod.Spec.Volumes {
+			if v.PersistentVolumeClaim == nil {
+				continue
+			}
+			pvc, err := client.CoreV1().PersistentVolumeClaims(pod.GetNamespace()).Get(v.PersistentVolumeClaim.ClaimName, meta.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			if pvc.Spec.StorageClassName == nil {
+				continue
+			}
+
+			if _, found := storageClassesSet[*pvc.Spec.StorageClassName]; found {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
 }
 
 // UnprotectedPodFilter returns a FilterFunc that returns true if the


### PR DESCRIPTION
Today we are filtering with out some node/pods because of statefulset. The reason is that most of the statefulsets are using localstorage, but some don't and can enter into the draino scope.

This new filter allow us to filter based on the nature of the local-storage and not on the kind of the controller used for the pod.

```
k get -A sts -ojson | jq -r '.items[] | .metadata.namespace+"/"+.metadata.name+" : "+.spec.volumeClaimTemplates[]?.spec.storageClassName' | grep -v local-data
```