### PR TITLE
Drain group and custom drain buffer

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -74,6 +74,7 @@ func main() {
 		doNotEvictPodControlledBy = app.Flag("do-not-evict-pod-controlled-by", "Do not evict pods that are controlled by the designated kind, empty VALUE for uncontrolled pods, May be specified multiple times.").PlaceHolder("kind[[.version].group]] examples: StatefulSets StatefulSets.apps StatefulSets.apps.v1").Default("", kubernetes.KindStatefulSet, kubernetes.KindDaemonSet).Strings()
 		evictLocalStoragePods     = app.Flag("evict-emptydir-pods", "Evict pods with local storage, i.e. with emptyDir volumes.").Bool()
 		protectedPodAnnotations   = app.Flag("protected-pod-annotation", "Protect pods with this annotation from eviction. May be specified multiple times.").PlaceHolder("KEY[=VALUE]").Strings()
+		drainGroupLabelKey        = app.Flag("drain-group-labels", "Comma separated list of label keys to be used to form draining groups.").PlaceHolder("KEY1,KEY2,...").Default("").String()
 
 		// Cordon filtering flags
 		doNotCordonPodControlledBy    = app.Flag("do-not-cordon-pod-controlled-by", "Do not cordon nodes hosting pods that are controlled by the designated kind, empty VALUE for uncontrolled pods, May be specified multiple times.").PlaceHolder("kind[[.version].group]] examples: StatefulSets StatefulSets.apps StatefulSets.apps.v1").Default("", kubernetes.KindStatefulSet).Strings()
@@ -249,6 +250,7 @@ func main() {
 		kubernetes.NewEventRecorder(cs),
 		kubernetes.WithLogger(log),
 		kubernetes.WithDrainBuffer(*drainBuffer),
+		kubernetes.WithDrainGroups(*drainGroupLabelKey),
 		kubernetes.WithConditionsFilter(*conditions),
 		kubernetes.WithCordonPodFilter(kubernetes.NewPodFilters(pf_cordon...), pods))
 
@@ -260,6 +262,7 @@ func main() {
 				kubernetes.NewEventRecorder(cs),
 				kubernetes.WithLogger(log),
 				kubernetes.WithDrainBuffer(*drainBuffer),
+				kubernetes.WithDrainGroups(*drainGroupLabelKey),
 				kubernetes.WithConditionsFilter(*conditions)),
 		}
 	}

--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -3,6 +3,8 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,78 +21,151 @@ import (
 const (
 	SetConditionTimeout     = 10 * time.Second
 	SetConditionRetryPeriod = 50 * time.Millisecond
+
+	CustomDrainBufferAnnotation = "draino/drain-buffer"
+	DrainGroupAnnotation        = "draino/drain-group"
 )
 
 type DrainScheduler interface {
-	HasSchedule(name string) (has, failed bool)
+	HasSchedule(node *v1.Node) (has, failed bool)
 	Schedule(node *v1.Node) (time.Time, error)
-	DeleteSchedule(name string)
+	DeleteSchedule(node *v1.Node)
+	DeleteScheduleByName(nodeName string)
+}
+
+type SchedulesGroup struct {
+	schedules      map[string]*schedule
+	schedulesChain []string
+	period         time.Duration
 }
 
 type DrainSchedules struct {
 	sync.Mutex
-	schedules map[string]*schedule
-
-	lastDrainScheduledFor time.Time
-	period                time.Duration
+	labelKeysForGroups []string
+	scheduleGroups     map[string]*SchedulesGroup
+	period             time.Duration
 
 	logger        *zap.Logger
 	drainer       Drainer
 	eventRecorder record.EventRecorder
 }
 
-func NewDrainSchedules(drainer Drainer, eventRecorder record.EventRecorder, period time.Duration, logger *zap.Logger) DrainScheduler {
+func NewDrainSchedules(drainer Drainer, eventRecorder record.EventRecorder, period time.Duration, labelKeysForGroups []string, logger *zap.Logger) DrainScheduler {
+	sort.Strings(labelKeysForGroups)
 	return &DrainSchedules{
-		schedules:     map[string]*schedule{},
-		period:        period,
-		logger:        logger,
-		drainer:       drainer,
-		eventRecorder: eventRecorder,
+		labelKeysForGroups: labelKeysForGroups,
+		scheduleGroups:     map[string]*SchedulesGroup{},
+		period:             period,
+		logger:             logger,
+		drainer:            drainer,
+		eventRecorder:      eventRecorder,
 	}
 }
 
-func (d *DrainSchedules) HasSchedule(name string) (has, failed bool) {
+func (d *DrainSchedules) getScheduleGroup(node *v1.Node) *SchedulesGroup {
+	values := []string{}
+	nodeLabels := node.Labels
+	if nodeLabels == nil {
+		nodeLabels = map[string]string{}
+	}
+	for _, key := range d.labelKeysForGroups {
+		values = append(values, nodeLabels[key])
+	}
+	if node.Annotations != nil {
+		values = append(values, node.Annotations[DrainGroupAnnotation])
+	}
+	groupKey := strings.Join(values, "#")
+
+	if group, ok := d.scheduleGroups[groupKey]; ok {
+		return group
+	}
+	newGroup := SchedulesGroup{
+		schedules: map[string]*schedule{},
+		period:    d.period,
+	}
+	d.scheduleGroups[groupKey] = &newGroup
+	return &newGroup
+}
+
+func (d *DrainSchedules) HasSchedule(node *v1.Node) (has, failed bool) {
 	d.Lock()
 	defer d.Unlock()
-	sched, ok := d.schedules[name]
+	grp := d.getScheduleGroup(node)
+	sched, ok := grp.schedules[node.GetName()]
 	if !ok {
 		return false, false
 	}
 	return true, sched.isFailed()
 }
 
-func (d *DrainSchedules) DeleteSchedule(name string) {
+func (d *DrainSchedules) DeleteSchedule(node *v1.Node) {
 	d.Lock()
 	defer d.Unlock()
-	if s, ok := d.schedules[name]; ok {
-		s.timer.Stop()
-	} else {
-		return
-	}
-	delete(d.schedules, name)
+	d.getScheduleGroup(node).removeSchedule(node.Name)
 }
 
-func (d *DrainSchedules) WhenNextSchedule() time.Time {
+func (d *DrainSchedules) DeleteScheduleByName(name string) {
+	d.Lock()
+	defer d.Unlock()
+	for _, grp := range d.scheduleGroups {
+		grp.removeSchedule(name)
+	}
+}
+
+func (sg *SchedulesGroup) whenNextSchedule() time.Time {
 	// compute drain schedule time
 	sooner := time.Now().Add(SetConditionTimeout + time.Second)
-	when := d.lastDrainScheduledFor.Add(d.period)
+	period := sg.period
+	var when time.Time
+	if len(sg.schedulesChain) > 0 {
+		lastScheduleName := sg.schedulesChain[len(sg.schedulesChain)-1]
+		if lastSchedule, ok := sg.schedules[lastScheduleName]; ok {
+			if lastSchedule.customDrainBuffer != nil {
+				fmt.Printf("found custom drain buffer\n")
+				period = *lastSchedule.customDrainBuffer
+			}
+			when = lastSchedule.when.Add(period)
+		}
+	}
 	if when.Before(sooner) {
 		when = sooner
 	}
+	fmt.Printf("sched: %v\n", when)
 	return when
+}
+
+func (sg *SchedulesGroup) addSchedule(node *v1.Node, scheduleRunner func(node *v1.Node, when time.Time) *schedule) time.Time {
+	when := sg.whenNextSchedule()
+	sg.schedulesChain = append(sg.schedulesChain, node.GetName())
+	sg.schedules[node.GetName()] = scheduleRunner(node, when)
+	return when
+}
+
+func (sg *SchedulesGroup) removeSchedule(name string) {
+	if s, ok := sg.schedules[name]; ok {
+		s.timer.Stop()
+		delete(sg.schedules, name)
+	}
+	newScheduleChain := []string{}
+	for _, scheduleName := range sg.schedulesChain {
+		if scheduleName == name {
+			continue
+		}
+		newScheduleChain = append(newScheduleChain, scheduleName)
+	}
+	sg.schedulesChain = newScheduleChain
 }
 
 func (d *DrainSchedules) Schedule(node *v1.Node) (time.Time, error) {
 	d.Lock()
-	if sched, ok := d.schedules[node.GetName()]; ok {
+	scheduleGroup := d.getScheduleGroup(node)
+	if sched, ok := scheduleGroup.schedules[node.GetName()]; ok {
 		d.Unlock()
 		return sched.when, NewAlreadyScheduledError() // we already have a schedule planned
 	}
 
 	// compute drain schedule time
-	when := d.WhenNextSchedule()
-	d.lastDrainScheduledFor = when
-	d.schedules[node.GetName()] = d.newSchedule(node, when)
+	when := scheduleGroup.addSchedule(node, d.newSchedule)
 	d.Unlock()
 
 	// Mark the node with the condition stating that drain is scheduled
@@ -102,17 +177,18 @@ func (d *DrainSchedules) Schedule(node *v1.Node) (time.Time, error) {
 		SetConditionTimeout,
 	); err != nil {
 		// if we cannot mark the node, let's remove the schedule
-		d.DeleteSchedule(node.GetName())
+		d.DeleteSchedule(node)
 		return time.Time{}, err
 	}
 	return when, nil
 }
 
 type schedule struct {
-	when   time.Time
-	failed int32
-	finish time.Time
-	timer  *time.Timer
+	when              time.Time
+	customDrainBuffer *time.Duration
+	failed            int32
+	finish            time.Time
+	timer             *time.Timer
 }
 
 func (s *schedule) setFailed() {
@@ -124,12 +200,20 @@ func (s *schedule) isFailed() bool {
 }
 
 func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time) *schedule {
+	nr := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
 	sched := &schedule{
 		when: when,
 	}
+	if customDrainBuffer, ok := node.Annotations[CustomDrainBufferAnnotation]; ok {
+		durationValue, err := time.ParseDuration(customDrainBuffer)
+		if err != nil {
+			d.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainConfig, "Failed to parse custom drain-buffer: %s", customDrainBuffer)
+		}
+		sched.customDrainBuffer = &durationValue
+	}
+
 	sched.timer = time.AfterFunc(time.Until(when), func() {
 		log := d.logger.With(zap.String("node", node.GetName()))
-		nr := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
 		tags, _ := tag.New(context.Background(), tag.Upsert(TagNodeName, node.GetName())) // nolint:gosec
 		d.eventRecorder.Event(nr, core.EventTypeWarning, eventReasonDrainStarting, "Draining node")
 		if err := d.drainer.Drain(node); err != nil {

--- a/internal/kubernetes/drainSchedule_test.go
+++ b/internal/kubernetes/drainSchedule_test.go
@@ -15,8 +15,9 @@ import (
 func TestDrainSchedules_Schedule(t *testing.T) {
 	fmt.Println("Now: " + time.Now().Format(time.RFC3339))
 	period := time.Minute
-	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, zap.NewNop())
-	whenFirstSched := scheduler.(*DrainSchedules).WhenNextSchedule()
+	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, []string{}, zap.NewNop())
+	whenFirstSched, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNode"}})
+	whenFirstSchedSpecificGroup, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNodeGrp", Annotations: map[string]string{DrainGroupAnnotation: "grp1"}}})
 
 	type timeWindow struct {
 		from, to time.Time
@@ -29,34 +30,50 @@ func TestDrainSchedules_Schedule(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "first schedule",
+			name: "first schedule in default group",
 			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}},
-			window: timeWindow{
-				from: whenFirstSched,
-				to:   whenFirstSched.Add(2 * time.Second),
-			},
-		},
-		{
-			name: "second schedule",
-			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName + "2"}},
 			window: timeWindow{
 				from: whenFirstSched.Add(period - 2*time.Second),
 				to:   whenFirstSched.Add(period + 2*time.Second),
 			},
 		},
 		{
-			name: "third schedule",
-			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName + "3"}},
+			name: "second schedule in default group",
+			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName + "2"}},
 			window: timeWindow{
 				from: whenFirstSched.Add(2*period - 2*time.Second),
 				to:   whenFirstSched.Add(2*period + 2*time.Second),
+			},
+		},
+		{
+			name: "a schedule in group grp1",
+			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName + "othergrp", Annotations: map[string]string{DrainGroupAnnotation: "grp1"}}},
+			window: timeWindow{
+				from: whenFirstSchedSpecificGroup.Add(period - 2*time.Second),
+				to:   whenFirstSchedSpecificGroup.Add(period + 2*time.Second),
+			},
+		},
+		{
+			name: "third schedule in default group",
+			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName + "3", Annotations: map[string]string{CustomDrainBufferAnnotation: "5m"}}},
+			window: timeWindow{
+				from: whenFirstSched.Add(3*period - 2*time.Second),
+				to:   whenFirstSched.Add(3*period + 2*time.Second),
+			},
+		},
+		{
+			name: "fourth schedule (following 5m custom drain buffer) in default group",
+			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName + "4"}},
+			window: timeWindow{
+				from: whenFirstSched.Add(3*period + 5*time.Minute - 2*time.Second),
+				to:   whenFirstSched.Add(3*period + 5*time.Minute + 2*time.Second),
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Check that node is not yet scheduled for drain
-			hasSchedule, _ := scheduler.HasSchedule(tt.node.Name)
+			hasSchedule, _ := scheduler.HasSchedule(tt.node)
 			if hasSchedule {
 				t.Errorf("Node %v should not have any schedule", tt.node.Name)
 			}
@@ -67,20 +84,13 @@ func TestDrainSchedules_Schedule(t *testing.T) {
 				return
 			}
 			// Check that node is scheduled for drain
-			hasSchedule, _ = scheduler.HasSchedule(tt.node.Name)
+			hasSchedule, _ = scheduler.HasSchedule(tt.node)
 			if !hasSchedule {
 				t.Errorf("Missing schedule record for node %v", tt.node.Name)
 			}
-			// Check that scheduled are place in the goog time window
+			// Check that scheduled are place in the good time window
 			if when.Before(tt.window.from) || when.After(tt.window.to) {
 				t.Errorf("Schedule out of timeWindow")
-			}
-			// Deleting schedule
-			scheduler.DeleteSchedule(tt.node.Name)
-			// Check that node is no more scheduled for drain
-			hasSchedule, _ = scheduler.HasSchedule(tt.node.Name)
-			if hasSchedule {
-				t.Errorf("Node %v should not been scheduled anymore", tt.node.Name)
 			}
 		})
 	}
@@ -95,7 +105,7 @@ func (d *failDrainer) Drain(n *v1.Node) error { return errors.New("myerr") }
 // Test to ensure there are no races when calling HasSchedule while the
 // scheduler is draining a node.
 func TestDrainSchedules_HasSchedule_Polling(t *testing.T) {
-	scheduler := NewDrainSchedules(&failDrainer{}, &record.FakeRecorder{}, 0, zap.NewNop())
+	scheduler := NewDrainSchedules(&failDrainer{}, &record.FakeRecorder{}, 0, []string{}, zap.NewNop())
 	node := &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}}
 
 	when, err := scheduler.Schedule(node)
@@ -105,7 +115,7 @@ func TestDrainSchedules_HasSchedule_Polling(t *testing.T) {
 
 	timeout := time.After(time.Until(when) + time.Minute)
 	for {
-		hasSchedule, failed := scheduler.HasSchedule(node.Name)
+		hasSchedule, failed := scheduler.HasSchedule(node)
 		if !hasSchedule {
 			t.Fatalf("Missing schedule record for node %v", node.Name)
 		}
@@ -125,5 +135,71 @@ func TestDrainSchedules_HasSchedule_Polling(t *testing.T) {
 			// some bug caused the draining function never to be scheduled.
 			t.Fatalf("timeout waiting for HasSchedule to fail")
 		}
+	}
+}
+
+func TestDrainSchedules_DeleteSchedule(t *testing.T) {
+	fmt.Println("Now: " + time.Now().Format(time.RFC3339))
+	period := time.Minute
+	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, []string{}, zap.NewNop())
+	whenFirstSched, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNode"}})
+
+	type timeWindow struct {
+		from, to time.Time
+	}
+
+	tests := []struct {
+		name    string
+		node    *v1.Node
+		window  timeWindow
+		wantErr bool
+	}{
+		{
+			name: "first schedule",
+			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}},
+			window: timeWindow{
+				from: whenFirstSched.Add(period - 2*time.Second),
+				to:   whenFirstSched.Add(period + 2*time.Second),
+			},
+		},
+		{
+			name: "second schedule",
+			node: &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName + "2"}},
+			window: timeWindow{
+				from: whenFirstSched.Add(period - 2*time.Second),
+				to:   whenFirstSched.Add(period + 2*time.Second),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Check that node is not yet scheduled for drain
+			hasSchedule, _ := scheduler.HasSchedule(tt.node)
+			if hasSchedule {
+				t.Errorf("Node %v should not have any schedule", tt.node.Name)
+			}
+
+			when, err := scheduler.Schedule(tt.node)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DrainSchedules.Schedule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// Check that scheduled are place in the good time window
+			if when.Before(tt.window.from) || when.After(tt.window.to) {
+				t.Errorf("Schedule out of timeWindow")
+			}
+			// Check that node is scheduled for drain
+			hasSchedule, _ = scheduler.HasSchedule(tt.node)
+			if !hasSchedule {
+				t.Errorf("Missing schedule record for node %v", tt.node.Name)
+			}
+			// Deleting schedule
+			scheduler.DeleteSchedule(tt.node)
+			// Check that node is no more scheduled for drain
+			hasSchedule, _ = scheduler.HasSchedule(tt.node)
+			if hasSchedule {
+				t.Errorf("Node %v should not been scheduled anymore", tt.node.Name)
+			}
+		})
 	}
 }

--- a/internal/kubernetes/eventhandler_test.go
+++ b/internal/kubernetes/eventhandler_test.go
@@ -72,10 +72,10 @@ func (d *mockCordonDrainer) MarkDrain(n *core.Node, when, finish time.Time, fail
 	return nil
 }
 
-func (d *mockCordonDrainer) HasSchedule(name string) (has, failed bool) {
+func (d *mockCordonDrainer) HasSchedule(node *core.Node) (has, failed bool) {
 	d.calls = append(d.calls, mockCall{
 		name: "HasSchedule",
-		node: name,
+		node: node.Name,
 	})
 	return false, false
 }
@@ -88,7 +88,14 @@ func (d *mockCordonDrainer) Schedule(node *core.Node) (time.Time, error) {
 	return time.Now(), nil
 }
 
-func (d *mockCordonDrainer) DeleteSchedule(name string) {
+func (d *mockCordonDrainer) DeleteSchedule(node *core.Node) {
+	d.calls = append(d.calls, mockCall{
+		name: "DeleteSchedule",
+		node: node.Name,
+	})
+}
+
+func (d *mockCordonDrainer) DeleteScheduleByName(name string) {
 	d.calls = append(d.calls, mockCall{
 		name: "DeleteSchedule",
 		node: name,

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -70,7 +70,7 @@ func RetryWithTimeout(f func() error, retryPeriod, timeout time.Duration) error 
 func GetAPIResources(discoveryClient discovery.DiscoveryInterface) ([]metav1.APIResource, error) {
 	groupList, err := discoveryClient.ServerGroups()
 	if groupList == nil || err != nil || groupList.Groups == nil {
-		return nil, fmt.Errorf("failed to discover groups")
+		return nil, fmt.Errorf("Fail to discover groups. Error: %v\n", err)
 	}
 
 	var allServerResources []metav1.APIResource


### PR DESCRIPTION
Thanks to this PR draino creates drain schedules per groups of nodes. We use to have one drain scheduled every 3 minutes for the whole cluster. Now it is possible to have a drain scheduled every 3min per drain-group. For example if the drain group is defined like:
```
--drain-buffer=3m
--drain-group-labels=nodegroups.datadoghq.com/namespace
```
that means that we can have a drain scheduled every 3 minutes in each namespace.
If we do:
```
--drain-buffer=3m
--drain-group-labels=nodegroups.datadoghq.com/namespace,nodegroups.datadoghq.com/name
```
that means that we can have d drain scheduled every 3 minutes per nodegroup.

Application owner can extend the grouping by adding their group name as annotation with `draino/drain-group`