### PR TITLE
fix rate limiting: burst=0 is not a good idea

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -250,7 +250,7 @@ func main() {
 		cordonLimiter.AddLimiter("MaxSimultaneousCordonLimiterForTaints:"+p, kubernetes.MaxSimultaneousCordonLimiterForTaintsFunc(max, percent, keys))
 	}
 
-	nodeReplacementLimiter := kubernetes.NewNodeReplacementLimiter(*maxNodeReplacementPerHour)
+	nodeReplacementLimiter := kubernetes.NewNodeReplacementLimiter(*maxNodeReplacementPerHour,time.Now())
 
 	var h cache.ResourceEventHandler = kubernetes.NewDrainingResourceEventHandler(
 		kubernetes.NewAPICordonDrainer(cs,

--- a/internal/kubernetes/limiter.go
+++ b/internal/kubernetes/limiter.go
@@ -49,12 +49,12 @@ func (l *limiterForNodeReplacement) CanAskForNodeReplacement() bool {
 	return true
 }
 
-func NewNodeReplacementLimiter(numberOfNodesPerHours int) NodeReplacementLimiter {
+func NewNodeReplacementLimiter(numberOfNodesPerHours int, currentTime time.Time) NodeReplacementLimiter {
 	qps := float32(numberOfNodesPerHours) / 3600
 	minutePeriod := 60 / numberOfNodesPerHours
 	return &limiterForNodeReplacement{
-		noReplacementBefore: time.Now().Add(time.Duration(minutePeriod) * time.Minute),
-		rateLimiter:         flowcontrol.NewTokenBucketRateLimiter(qps, 0),
+		noReplacementBefore: currentTime.Add(time.Duration(minutePeriod) * time.Minute),
+		rateLimiter:         flowcontrol.NewTokenBucketRateLimiter(qps, 1),
 	}
 }
 

--- a/internal/kubernetes/limiter_test.go
+++ b/internal/kubernetes/limiter_test.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -417,5 +418,18 @@ func TestIsLimiterError(t *testing.T) {
 				t.Errorf("IsLimiterError() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNodeReplacementLimiter(t *testing.T) {
+	limiter:= NewNodeReplacementLimiter(2,time.Now().Add(-2*time.Hour))
+	if !limiter.CanAskForNodeReplacement() {
+		t.FailNow()
+	}
+	if limiter.CanAskForNodeReplacement() {
+		t.FailNow()
+	}
+	if limiter.CanAskForNodeReplacement() {
+		t.FailNow()
 	}
 }


### PR DESCRIPTION
I was using `flowcontrol.NewRateLimit` with `burst=0` ... it was not a good idea, it needs to be at least 1, else no request can go through the limiter.

Adding a unittest associated to that.