### PR TITLE
pre-provisioning node before drain

### DIFF
--- a/internal/kubernetes/drainSchedule_test.go
+++ b/internal/kubernetes/drainSchedule_test.go
@@ -15,7 +15,7 @@ import (
 func TestDrainSchedules_Schedule(t *testing.T) {
 	fmt.Println("Now: " + time.Now().Format(time.RFC3339))
 	period := time.Minute
-	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, []string{}, []SuppliedCondition{}, zap.NewNop())
+	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop())
 	whenFirstSched, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNode"}})
 	whenFirstSchedSpecificGroup, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNodeGrp", Annotations: map[string]string{DrainGroupAnnotation: "grp1"}}})
 
@@ -105,7 +105,7 @@ func (d *failDrainer) Drain(n *v1.Node) error { return errors.New("myerr") }
 // Test to ensure there are no races when calling HasSchedule while the
 // scheduler is draining a node.
 func TestDrainSchedules_HasSchedule_Polling(t *testing.T) {
-	scheduler := NewDrainSchedules(&failDrainer{}, &record.FakeRecorder{}, 0, []string{}, []SuppliedCondition{}, zap.NewNop())
+	scheduler := NewDrainSchedules(&failDrainer{}, &record.FakeRecorder{}, 0, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop())
 	node := &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}}
 
 	when, err := scheduler.Schedule(node)
@@ -141,7 +141,7 @@ func TestDrainSchedules_HasSchedule_Polling(t *testing.T) {
 func TestDrainSchedules_DeleteSchedule(t *testing.T) {
 	fmt.Println("Now: " + time.Now().Format(time.RFC3339))
 	period := time.Minute
-	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, []string{}, []SuppliedCondition{}, zap.NewNop())
+	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop())
 	whenFirstSched, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNode"}})
 
 	type timeWindow struct {

--- a/internal/kubernetes/eventhandler_test.go
+++ b/internal/kubernetes/eventhandler_test.go
@@ -121,6 +121,14 @@ func (d *mockCordonDrainer) ReplaceNode(n *core.Node) (NodeReplacementStatus, er
 	return NodeReplacementStatusNone, nil
 }
 
+func (d *mockCordonDrainer) PreprovisionNode(n *core.Node) (NodeReplacementStatus, error) {
+	d.calls = append(d.calls, mockCall{
+		name: "PreprovisionNode",
+		node: n.Name,
+	})
+	return NodeReplacementStatusNone, nil
+}
+
 func TestDrainingResourceEventHandler(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
Allow user to request node pre-provisioning before starting the drain.
This is achieved thanks to a dedicated annotation on the node to be drained.

The node pre-provisioning is done with the same API than for node-replacement but without the rate limiting.