### PR TITLE
opt-in filtering for pods

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -285,7 +285,7 @@ func main() {
 		kubernetes.MaxGracePeriod(*maxGracePeriod),
 		kubernetes.EvictionHeadroom(*evictionHeadroom),
 		kubernetes.WithSkipDrain(*skipDrain),
-		kubernetes.WithPodFilter(kubernetes.NewPodFiltersWithOptInFirst(kubernetes.UserOptInViaPodAnnotation(*optInPodAnnotations...), kubernetes.NewPodFilters(pf...))),
+		kubernetes.WithPodFilter(kubernetes.NewPodFiltersWithOptInFirst(kubernetes.PodHasAnyOfTheAnnotations(*optInPodAnnotations...), kubernetes.NewPodFilters(pf...))),
 		kubernetes.WithCordonLimiter(cordonLimiter),
 		kubernetes.WithNodeReplacementLimiter(nodeReplacementLimiter),
 		kubernetes.WithStorageClassesAllowingDeletion(*storageClassesAllowingVolumeDeletion),
@@ -300,7 +300,7 @@ func main() {
 		kubernetes.WithDurationWithCompletedStatusBeforeReplacement(*durationBeforeReplacement),
 		kubernetes.WithDrainGroups(*drainGroupLabelKey),
 		kubernetes.WithConditionsFilter(*conditions),
-		kubernetes.WithCordonPodFilter(kubernetes.NewPodFiltersWithOptInFirst(kubernetes.UserOptInViaPodAnnotation(*optInPodAnnotations...), kubernetes.NewPodFilters(podFilterCordon...)), pods),
+		kubernetes.WithCordonPodFilter(kubernetes.NewPodFiltersWithOptInFirst(kubernetes.PodHasAnyOfTheAnnotations(*optInPodAnnotations...), kubernetes.NewPodFilters(podFilterCordon...)), pods),
 		kubernetes.WithPreprovisioningConfiguration(kubernetes.NodePreprovisioningConfiguration{Timeout: *preprovisioningTimeout, CheckPeriod: *preprovisioningCheckPeriod}))
 
 	if *dryRun {
@@ -349,7 +349,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	scopeObserver := kubernetes.NewScopeObserver(cs, *configName, kubernetes.ParseConditions(*conditions), nodes, pods, *scopeAnalysisPeriod, kubernetes.NewPodFilters(podFilterCordon...), kubernetes.UserOptOutViaPodAnnotation(*cordonProtectedPodAnnotations...), nodeLabelFilterFunc, log)
+	scopeObserver := kubernetes.NewScopeObserver(cs, *configName, kubernetes.ParseConditions(*conditions), nodes, pods, *scopeAnalysisPeriod, kubernetes.NewPodFilters(podFilterCordon...), kubernetes.PodHasAnyOfTheAnnotations(*cordonProtectedPodAnnotations...), nodeLabelFilterFunc, log)
 	go scopeObserver.Run(ctx.Done())
 	if *resetScopeAnnotation == true {
 		go scopeObserver.Reset()

--- a/internal/kubernetes/podfilters_test.go
+++ b/internal/kubernetes/podfilters_test.go
@@ -17,9 +17,9 @@ and limitations under the License.
 package kubernetes
 
 import (
+	"errors"
 	"testing"
 
-	"errors"
 	v1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -493,6 +493,97 @@ func TestPodFilters(t *testing.T) {
 				}})
 			},
 			passesFilter: false,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - empty list",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{}...)
+			},
+			passesFilter: false,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - non empty list - no annotation",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{"test=1"}...)
+			},
+			passesFilter: false,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - match",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1"}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{"test=1"}...)
+			},
+			passesFilter: true,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - match key not value",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1"}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{"test=2"}...)
+			},
+			passesFilter: false,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - match key empty value",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": ""}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{"test="}...)
+			},
+			passesFilter: true,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - match key empty value no equal sign",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": ""}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{"test"}...)
+			},
+			passesFilter: true,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - match one in list",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{"aaa=bbb", "test=1"}...)
+			},
+			passesFilter: true,
+		},
+		{
+			name: "podHasAnyOfTheAnnotations - no match in list",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return podHasAnyOfTheAnnotations([]string{"test", "whatever"}...)
+			},
+			passesFilter: false,
+		},
+		{
+			name: "NewPodFiltersWithOptInFirst - no opt-in and filter true",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return NewPodFiltersWithOptInFirst(UserOptInViaPodAnnotation(nil...),
+					func(p core.Pod) (pass bool, reason string, err error) { return true, "", nil })
+			},
+			passesFilter: true,
+		},
+		{
+			name: "NewPodFiltersWithOptInFirst - no opt-in and filter false",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return NewPodFiltersWithOptInFirst(UserOptInViaPodAnnotation(nil...),
+					func(p core.Pod) (pass bool, reason string, err error) { return false, "", nil })
+			},
+			passesFilter: false,
+		},
+		{
+			name: "NewPodFiltersWithOptInFirst - opt-in and filter false",
+			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
+			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
+				return NewPodFiltersWithOptInFirst(UserOptInViaPodAnnotation([]string{"foo=bar"}...),
+					func(p core.Pod) (pass bool, reason string, err error) { return false, "", nil })
+			},
+			passesFilter: true,
 		},
 	}
 

--- a/internal/kubernetes/podfilters_test.go
+++ b/internal/kubernetes/podfilters_test.go
@@ -495,74 +495,74 @@ func TestPodFilters(t *testing.T) {
 			passesFilter: false,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - empty list",
+			name: "PodHasAnyOfTheAnnotations - empty list",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{}...)
+				return PodHasAnyOfTheAnnotations([]string{}...)
 			},
 			passesFilter: false,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - non empty list - no annotation",
+			name: "PodHasAnyOfTheAnnotations - non empty list - no annotation",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{"test=1"}...)
+				return PodHasAnyOfTheAnnotations([]string{"test=1"}...)
 			},
 			passesFilter: false,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - match",
+			name: "PodHasAnyOfTheAnnotations - match",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1"}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{"test=1"}...)
+				return PodHasAnyOfTheAnnotations([]string{"test=1"}...)
 			},
 			passesFilter: true,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - match key not value",
+			name: "PodHasAnyOfTheAnnotations - match key not value",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1"}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{"test=2"}...)
+				return PodHasAnyOfTheAnnotations([]string{"test=2"}...)
 			},
 			passesFilter: false,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - match key empty value",
+			name: "PodHasAnyOfTheAnnotations - match key empty value",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": ""}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{"test="}...)
+				return PodHasAnyOfTheAnnotations([]string{"test="}...)
 			},
 			passesFilter: true,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - match key empty value no equal sign",
+			name: "PodHasAnyOfTheAnnotations - match key empty value no equal sign",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": ""}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{"test"}...)
+				return PodHasAnyOfTheAnnotations([]string{"test"}...)
 			},
 			passesFilter: true,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - match one in list",
+			name: "PodHasAnyOfTheAnnotations - match one in list",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{"aaa=bbb", "test=1"}...)
+				return PodHasAnyOfTheAnnotations([]string{"aaa=bbb", "test=1"}...)
 			},
 			passesFilter: true,
 		},
 		{
-			name: "podHasAnyOfTheAnnotations - no match in list",
+			name: "PodHasAnyOfTheAnnotations - match key in list",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return podHasAnyOfTheAnnotations([]string{"test", "whatever"}...)
+				return PodHasAnyOfTheAnnotations([]string{"test", "whatever"}...)
 			},
-			passesFilter: false,
+			passesFilter: true,
 		},
 		{
 			name: "NewPodFiltersWithOptInFirst - no opt-in and filter true",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return NewPodFiltersWithOptInFirst(UserOptInViaPodAnnotation(nil...),
+				return NewPodFiltersWithOptInFirst(PodHasAnyOfTheAnnotations(nil...),
 					func(p core.Pod) (pass bool, reason string, err error) { return true, "", nil })
 			},
 			passesFilter: true,
@@ -571,7 +571,7 @@ func TestPodFilters(t *testing.T) {
 			name: "NewPodFiltersWithOptInFirst - no opt-in and filter false",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return NewPodFiltersWithOptInFirst(UserOptInViaPodAnnotation(nil...),
+				return NewPodFiltersWithOptInFirst(PodHasAnyOfTheAnnotations(nil...),
 					func(p core.Pod) (pass bool, reason string, err error) { return false, "", nil })
 			},
 			passesFilter: false,
@@ -580,7 +580,7 @@ func TestPodFilters(t *testing.T) {
 			name: "NewPodFiltersWithOptInFirst - opt-in and filter false",
 			pod:  core.Pod{ObjectMeta: meta.ObjectMeta{Name: podName, Annotations: map[string]string{"test": "1", "foo": "bar", "other": "value"}}},
 			filterBuilderFunc: func(obj ...runtime.Object) PodFilterFunc {
-				return NewPodFiltersWithOptInFirst(UserOptInViaPodAnnotation([]string{"foo=bar"}...),
+				return NewPodFiltersWithOptInFirst(PodHasAnyOfTheAnnotations([]string{"foo=bar"}...),
 					func(p core.Pod) (pass bool, reason string, err error) { return false, "", nil })
 			},
 			passesFilter: true,


### PR DESCRIPTION
Introduce the ability for pods to opt-in via annotation.

exampele of usage: redis pod that are sts that are excluded from the drain standard configuration but that are compliant (PDB +readiness probe + EBS).