### PR TITLE
ability to put annotation for PVC management on the statefulset itsel…

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -381,7 +381,7 @@ func main() {
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				log.Info("watchers are running")
-				kingpin.FatalIfError(kubernetes.Await(nodes, pods), "error watching")
+				kingpin.FatalIfError(kubernetes.Await(nodes, pods, statefulSets), "error watching")
 			},
 			OnStoppedLeading: func() {
 				kingpin.Fatalf("lost leader election")

--- a/internal/kubernetes/podfilters.go
+++ b/internal/kubernetes/podfilters.go
@@ -78,11 +78,11 @@ func NewPodControlledByFilter(controlledByAPIResources []*meta.APIResource) PodF
 func UnprotectedPodFilter(annotations ...string) PodFilterFunc {
 	return func(p core.Pod) (bool, string, error) {
 		for _, annot := range annotations {
-			selector,err:=labels.Parse(annot)
-			if err!=nil {
-				return false,"",err
+			selector, err := labels.Parse(annot)
+			if err != nil {
+				return false, "", err
 			}
-			if selector.Matches(labels.Set(p.GetAnnotations())){
+			if selector.Matches(labels.Set(p.GetAnnotations())) {
 				return false, "pod-annotation", nil
 			}
 		}
@@ -93,11 +93,11 @@ func UnprotectedPodFilter(annotations ...string) PodFilterFunc {
 func PodHasAnyOfTheAnnotations(annotations ...string) PodFilterFunc {
 	return func(p core.Pod) (bool, string, error) {
 		for _, annot := range annotations {
-			selector,err:=labels.Parse(annot)
-			if err!=nil {
-				return false,"",err
+			selector, err := labels.Parse(annot)
+			if err != nil {
+				return false, "", err
 			}
-			if selector.Matches(labels.Set(p.GetAnnotations())){
+			if selector.Matches(labels.Set(p.GetAnnotations())) {
 				return true, "pod-annotation", nil
 			}
 		}


### PR DESCRIPTION
The PVC management annotation is to be set on the pod. This means that to modify the pods, a full rollout of the application is needed.
To avoid this rollout (just for a pod annotation change) we open the possibility to set the annotation on the STS instead of the pod.

To do that we have to run an informer on STS.
Also I regroup the different store under one structure, a store with {nodes,pods,sts} to pass it within other structs. This way it will be easier later to add other store.

In a next PR I will probably allow opt-in opt-out annotations on STS and Deployments instead of pods. I want to release this feature for PVC first to unlock situation with DRE.
