### PR TITLE
do not fail with error when delete pod return NotFound

### DIFF
--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -633,7 +633,7 @@ func (d *APICordonDrainer) podDeleteRetryWaitingForPVC(pod *core.Pod, pvc *core.
 
 		d.l.Info("deleting pod to force pvc recreate", zap.String("pod", pod.GetName()), zap.String("namespace", pod.GetNamespace()))
 		err = d.c.CoreV1().Pods(pod.GetNamespace()).Delete(pod.GetName(), &meta.DeleteOptions{})
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("cannot delete pod %s/%s to regenerated PVC: %w", pod.GetNamespace(), pod.GetName(), err)
 		}
 		return false, nil


### PR DESCRIPTION
When the deletion of the pod fails due to NotFound, we should not exit with error. It just means that the PVC cleanup was faster than the statefulset-controller that has not yet recreated the pod. In that case we should continue waiting for the PVC to be created, and possibly attempt a pod deletion again.