### PR TITLE
protect runner when there is no blocker defined

### DIFF
--- a/internal/kubernetes/blocker.go
+++ b/internal/kubernetes/blocker.go
@@ -62,8 +62,16 @@ var (
 func (g *GlobalBlocksRunner) Run(stopCh <-chan struct{}) {
 	if g.started {
 		g.logger.Error("GlobalBlocker run twice")
+		<-stopCh
 		return
 	}
+
+	if len(g.blockers)==0 {
+		g.logger.Info("No blocker to run")
+		<-stopCh
+		return
+	}
+
 	tagBlock, _ := tag.NewKey("block")
 	blockerView := &view.View{
 		Name:        "global_block",

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -601,6 +601,8 @@ func (d *APICordonDrainer) evictWithOperatorAPI(url string, pod *core.Pod, abort
 			defer resp.Body.Close()
 			d.l.Info("custom eviction endpoint response", zap.String("pod", pod.Namespace+"/"+pod.Name), zap.String("endpoint", url), zap.Int("responseCode", resp.StatusCode))
 			switch {
+			case resp.StatusCode == http.StatusOK:
+				return nil
 			case resp.StatusCode == http.StatusTooManyRequests:
 				return apierrors.NewTooManyRequests("retry later", 10)
 			case resp.StatusCode == http.StatusNotFound:


### PR DESCRIPTION
When there is no blocker configured the Blocker run should wait for the stopCh signal before returning