### PR TITLE
get url for eviction API on pod or on sts

### DIFF
--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -531,7 +531,7 @@ func (d *APICordonDrainer) GetPodsToDrain(node string, podStore PodStore) ([]*co
 }
 
 func (d *APICordonDrainer) evict(pod *core.Pod, abort <-chan struct{}) error {
-	evictionAPIURL, ok := pod.Annotations[EvictionAPIURLAnnotationKey]
+	evictionAPIURL, ok := GetAnnotationFromPodOrController(EvictionAPIURLAnnotationKey,pod,d.runtimeObjectStore)
 	if ok {
 		return d.evictWithOperatorAPI(evictionAPIURL, pod, abort)
 	}


### PR DESCRIPTION
This PR gives the ability for user to set the URL of eviction API on the STS annotation instead of every pod annotation.

cc @iksaif 