### PR TITLE
fix filter for observability and add LogForVerboseNode

### DIFF
--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -208,11 +208,12 @@ func (s *DrainoConfigurationObserverImpl) addNodeToQueue(node *v1.Node) {
 
 func (s *DrainoConfigurationObserverImpl) IsAnnotationUpdateNeeded(node *v1.Node) bool {
 	configs := strings.Split(node.Annotations[ConfigurationAnnotationKey], ",")
-	inScope, _, err := s.IsInScope(node)
+	inScope, reason, err := s.IsInScope(node)
 	if err != nil {
 		s.logger.Error("Can't check if node is in scope", zap.Error(err), zap.String("node", node.Name))
 		return false
 	}
+	LogForVerboseNode(s.logger, node, "InScope information", zap.Bool("inScope", inScope), zap.String("reason", reason))
 	if inScope {
 		for _, c := range configs {
 			if c == s.configName {

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -352,3 +352,9 @@ func GetReadinessState(node *core.Node) (isNodeReady bool, err error) {
 	}
 	return canNodeBeReady, nil
 }
+
+func LogForVerboseNode(logger *zap.Logger, node *core.Node, msg string, fields ...zap.Field) {
+	if node.Annotations["draino/logs"] == "verbose" {
+		logger.Info(msg, append(fields, zap.String("node", node.Name))...)
+	}
+}


### PR DESCRIPTION
Fix an issue with the filters that are passed to the observability layout: it was missing the opt-in filter

Add a new primitive to get log verbosity per node on demand: when node has the annotation `draino/logs=verbose`
