### PR TITLE
[COMPUTE-971] [control] automatic exponential backoff on drain retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run-in-rage: fmt vet
-	go run ./cmd/draino/*.go  --kubeconfig=$(KUBECONFIG) --namespace=rage-k8s \
+	go run ./cmd/draino/*.go  --kubeconfig=$(KUBECONFIG) --namespace=cluster-controllers \
 	  --debug \
       --leader-election-token-name=draino-standard \
       --drain-buffer=3m \
@@ -29,7 +29,7 @@ run-in-rage: fmt vet
       --max-notready-nodes=10% \
       --max-notready-nodes=50 \
       --max-pending-pods=10% \
-      --max-drain-attempts-before-fail=8 \
+      --max-drain-attempts-before-fail=7 \
       --do-not-evict-pod-controlled-by=StatefulSet \
       --do-not-evict-pod-controlled-by=DaemonSet \
       --do-not-evict-pod-controlled-by=ExtendedDaemonSetReplicaSet \

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,10 @@ run-in-rage: fmt vet
       --max-simultaneous-cordon-for-labels=15,app \
       --max-simultaneous-cordon-for-labels=15%,nodegroups.datadoghq.com/name,nodegroups.datadoghq.com/namespace \
       --max-simultaneous-cordon-for-labels=15,nodegroups.datadoghq.com/name,nodegroups.datadoghq.com/namespace \
-      --max-notready-nodes=1 \
-      --max-pending-pods=3 \
+      --max-notready-nodes=10% \
+      --max-notready-nodes=50 \
+      --max-pending-pods=10% \
+      --max-drain-attempts-before-fail=8 \
       --do-not-evict-pod-controlled-by=StatefulSet \
       --do-not-evict-pod-controlled-by=DaemonSet \
       --do-not-evict-pod-controlled-by=ExtendedDaemonSetReplicaSet \

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -315,7 +315,6 @@ func main() {
 
 	cordonDrainer := kubernetes.NewAPICordonDrainer(cs,
 		eventRecorder,
-		*maxDrainAttemptsBeforeFail,
 		kubernetes.MaxGracePeriod(*maxGracePeriod),
 		kubernetes.EvictionHeadroom(*evictionHeadroom),
 		kubernetes.WithSkipDrain(*skipDrain),
@@ -324,7 +323,7 @@ func main() {
 		kubernetes.WithCordonLimiter(cordonLimiter),
 		kubernetes.WithNodeReplacementLimiter(nodeReplacementLimiter),
 		kubernetes.WithStorageClassesAllowingDeletion(*storageClassesAllowingVolumeDeletion),
-		//kubernetes.WithMaxDrainAttemptsBeforeFail(*maxDrainAttemptsBeforeFail),
+		kubernetes.WithMaxDrainAttemptsBeforeFail(*maxDrainAttemptsBeforeFail),
 		kubernetes.WithAPICordonDrainerLogger(log),
 	)
 
@@ -342,7 +341,6 @@ func main() {
 		kubernetes.WithConditionsFilter(*conditions),
 		kubernetes.WithCordonPodFilter(podFilteringFunc, pods),
 		kubernetes.WithGlobalBlocking(globalLocker),
-		kubernetes.WithMaxDrainAttemptsBeforeFail(*maxDrainAttemptsBeforeFail),
 		kubernetes.WithPreprovisioningConfiguration(kubernetes.NodePreprovisioningConfiguration{Timeout: *preprovisioningTimeout, CheckPeriod: *preprovisioningCheckPeriod}))
 
 	if *dryRun {
@@ -356,7 +354,6 @@ func main() {
 				kubernetes.WithDurationWithCompletedStatusBeforeReplacement(*durationBeforeReplacement),
 				kubernetes.WithDrainGroups(*drainGroupLabelKey),
 				kubernetes.WithGlobalBlocking(globalLocker),
-				kubernetes.WithMaxDrainAttemptsBeforeFail(*maxDrainAttemptsBeforeFail),
 				kubernetes.WithConditionsFilter(*conditions)),
 		}
 	}

--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -190,7 +190,7 @@ func (d *DrainSchedules) Schedule(node *v1.Node, failedCount int32) (time.Time, 
 	// Mark the node with the condition stating that drain is scheduled
 	if err := RetryWithTimeout(
 		func() error {
-			return d.drainer.MarkDrain(node, when, time.Time{}, false, 0)
+			return d.drainer.MarkDrain(node, when, time.Time{}, false, failedCount)
 		},
 		SetConditionRetryPeriod,
 		SetConditionTimeout,
@@ -293,7 +293,7 @@ func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount 
 		d.eventRecorder.Event(nr, core.EventTypeWarning, eventReasonDrainSucceeded, "Drained node")
 		if err := RetryWithTimeout(
 			func() error {
-				return d.drainer.MarkDrain(node, when, sched.finish, false, 0)
+				return d.drainer.MarkDrain(node, when, sched.finish, false, failedCount)
 			},
 			SetConditionRetryPeriod,
 			SetConditionTimeout,

--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -35,7 +35,7 @@ const (
 
 type DrainScheduler interface {
 	HasSchedule(node *v1.Node) (has, failed bool)
-	Schedule(node *v1.Node) (time.Time, error)
+	Schedule(node *v1.Node, failedCount int32) (time.Time, error)
 	DeleteSchedule(node *v1.Node)
 	DeleteScheduleByName(nodeName string)
 }
@@ -150,10 +150,13 @@ func (sg *SchedulesGroup) whenNextSchedule() time.Time {
 	return when
 }
 
-func (sg *SchedulesGroup) addSchedule(node *v1.Node, scheduleRunner func(node *v1.Node, when time.Time) *schedule) time.Time {
+func (sg *SchedulesGroup) addSchedule(node *v1.Node, failedCount int32, scheduleRunner func(node *v1.Node, when time.Time, failedCount int32) *schedule) time.Time {
 	when := sg.whenNextSchedule()
+	if failedCount > 0 {
+		when = when.Add(time.Duration(2*failedCount) * time.Hour) // add backoff delay
+	}
 	sg.schedulesChain = append(sg.schedulesChain, node.GetName())
-	sg.schedules[node.GetName()] = scheduleRunner(node, when)
+	sg.schedules[node.GetName()] = scheduleRunner(node, when, failedCount)
 	return when
 }
 
@@ -172,7 +175,7 @@ func (sg *SchedulesGroup) removeSchedule(name string) {
 	sg.schedulesChain = newScheduleChain
 }
 
-func (d *DrainSchedules) Schedule(node *v1.Node) (time.Time, error) {
+func (d *DrainSchedules) Schedule(node *v1.Node, failedCount int32) (time.Time, error) {
 	d.Lock()
 	scheduleGroup := d.getScheduleGroup(node)
 	if sched, ok := scheduleGroup.schedules[node.GetName()]; ok {
@@ -181,13 +184,13 @@ func (d *DrainSchedules) Schedule(node *v1.Node) (time.Time, error) {
 	}
 
 	// compute drain schedule time
-	when := scheduleGroup.addSchedule(node, d.newSchedule)
+	when := scheduleGroup.addSchedule(node, failedCount, d.newSchedule)
 	d.Unlock()
 
 	// Mark the node with the condition stating that drain is scheduled
 	if err := RetryWithTimeout(
 		func() error {
-			return d.drainer.MarkDrain(node, when, time.Time{}, false)
+			return d.drainer.MarkDrain(node, when, time.Time{}, false, 0)
 		},
 		SetConditionRetryPeriod,
 		SetConditionTimeout,
@@ -203,6 +206,7 @@ type schedule struct {
 	when              time.Time
 	customDrainBuffer *time.Duration
 	failed            int32
+	failedCount       int32
 	finish            time.Time
 	timer             *time.Timer
 }
@@ -215,10 +219,11 @@ func (s *schedule) isFailed() bool {
 	return atomic.LoadInt32(&s.failed) == 1
 }
 
-func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time) *schedule {
+func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount int32) *schedule {
 	nr := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
 	sched := &schedule{
-		when: when,
+		when:        when,
+		failedCount: failedCount,
 	}
 	if customDrainBuffer, ok := node.Annotations[CustomDrainBufferAnnotation]; ok {
 		durationValue, err := time.ParseDuration(customDrainBuffer)
@@ -288,7 +293,7 @@ func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time) *schedule {
 		d.eventRecorder.Event(nr, core.EventTypeWarning, eventReasonDrainSucceeded, "Drained node")
 		if err := RetryWithTimeout(
 			func() error {
-				return d.drainer.MarkDrain(node, when, sched.finish, false)
+				return d.drainer.MarkDrain(node, when, sched.finish, false, 0)
 			},
 			SetConditionRetryPeriod,
 			SetConditionTimeout,
@@ -304,13 +309,14 @@ func (d *DrainSchedules) handleDrainFailure(sched *schedule, log *zap.Logger, dr
 	nr := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
 	sched.finish = time.Now()
 	sched.setFailed()
+	sched.failedCount++
 	log.Info("Failed to drain", zap.Error(drainError))
 	tags, _ = tag.New(tags, tag.Upsert(TagResult, tagResultFailed), tag.Upsert(TagFailureCause, string(getFailureCause(drainError)))) // nolint:gosec
 	StatRecordForEachCondition(tags, node, GetNodeOffendingConditions(node, d.suppliedConditions), MeasureNodesDrained.M(1))
 	d.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainFailed, "Draining failed: %v", drainError)
 	if err := RetryWithTimeout(
 		func() error {
-			return d.drainer.MarkDrain(node, sched.when, sched.finish, true)
+			return d.drainer.MarkDrain(node, sched.when, sched.finish, true, sched.failedCount)
 		},
 		SetConditionRetryPeriod,
 		SetConditionTimeout,

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -176,7 +176,7 @@ func TestCordon(t *testing.T) {
 			for _, r := range tc.reactions {
 				c.PrependReactor(r.verb, r.resource, r.Fn())
 			}
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, 1, WithCordonLimiter(&fakeLimiter{}))
+			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, WithCordonLimiter(&fakeLimiter{}))
 			if err := d.Cordon(tc.node, tc.mutators...); err != nil {
 				for _, r := range tc.reactions {
 					if errors.Is(err, r.err) {
@@ -263,7 +263,7 @@ func TestUncordon(t *testing.T) {
 			for _, r := range tc.reactions {
 				c.PrependReactor(r.verb, r.resource, r.Fn())
 			}
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, 1)
+			d := NewAPICordonDrainer(c, &record.FakeRecorder{})
 			if err := d.Uncordon(tc.node, tc.mutators...); err != nil {
 				for _, r := range tc.reactions {
 					if errors.Is(err, r.err) {
@@ -536,7 +536,7 @@ func TestDrain(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := newFakeClientSet(tc.reactions...)
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, 1, tc.options...)
+			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, tc.options...)
 			if err := d.Drain(tc.node); err != nil {
 				for _, r := range tc.reactions {
 					if errors.Is(err, r.err) {
@@ -632,7 +632,7 @@ func TestMarkDrain(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := fake.NewSimpleClientset(tc.node)
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, 1)
+			d := NewAPICordonDrainer(c, &record.FakeRecorder{})
 			{
 				n, err := c.CoreV1().Nodes().Get(tc.node.GetName(), meta.GetOptions{})
 				if err != nil {

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -552,6 +552,98 @@ func TestDrain(t *testing.T) {
 	}
 }
 
+func TestGetDrainConditionStatus(t *testing.T) {
+	now := meta.Time{Time: time.Now()}
+	cases := []struct {
+		name        string
+		node        *core.Node
+		drainStatus DrainConditionStatus
+		isErr       bool
+	}{
+		{
+			name:  "conditionStatus0",
+			node:  &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}},
+			isErr: false,
+		},
+		{
+			name: "conditionStatus1",
+			node: &core.Node{
+				ObjectMeta: meta.ObjectMeta{Name: nodeName},
+				Status: core.NodeStatus{
+					Conditions: []core.NodeCondition{
+						{
+							Type:               core.NodeConditionType(ConditionDrainedScheduled),
+							Status:             core.ConditionTrue,
+							LastHeartbeatTime:  now,
+							LastTransitionTime: now,
+							Reason:             "Draino",
+							Message:            "Drain activity scheduled",
+						},
+					},
+				},
+			},
+			drainStatus: DrainConditionStatus{Marked: true, FailedCount: 1, LastTransition: now.Time},
+			isErr:       false,
+		},
+		{
+			name: "conditionStatus failed(1)",
+			node: &core.Node{
+				ObjectMeta: meta.ObjectMeta{Name: nodeName},
+				Status: core.NodeStatus{
+					Conditions: []core.NodeCondition{
+						{
+							Type:               core.NodeConditionType(ConditionDrainedScheduled),
+							Status:             core.ConditionFalse,
+							LastHeartbeatTime:  now,
+							LastTransitionTime: now,
+							Reason:             "Draino",
+							Message:            "[1] | Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed: 2020-03-20T15:55:50+01:00",
+						},
+					},
+				},
+			},
+			drainStatus: DrainConditionStatus{Marked: true, Completed: false, Failed: true, FailedCount: 1, LastTransition: now.Time},
+			isErr:       false,
+		},
+		{
+			name: "conditionStatus Failed(2)",
+			node: &core.Node{
+				ObjectMeta: meta.ObjectMeta{Name: nodeName},
+				Status: core.NodeStatus{
+					Conditions: []core.NodeCondition{
+						{
+							Type:               core.NodeConditionType(ConditionDrainedScheduled),
+							Status:             core.ConditionFalse,
+							LastHeartbeatTime:  now,
+							LastTransitionTime: now,
+							Reason:             "Draino",
+							Message:            "[2] | Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed: 2020-03-20T15:55:50+01:00",
+						},
+					},
+				},
+			},
+			drainStatus: DrainConditionStatus{Marked: true, Completed: false, Failed: true, FailedCount: 2, LastTransition: now.Time},
+			isErr:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewSimpleClientset(tc.node)
+			{
+				n, err := c.CoreV1().Nodes().Get(tc.node.GetName(), meta.GetOptions{})
+				if err != nil {
+					t.Errorf("node.Get(%v): %v", tc.node.Name, err)
+				}
+				drainStatus, err := GetDrainConditionStatus(n)
+				if drainStatus != tc.drainStatus {
+					t.Errorf("node %v initial drainStatus is not correct", tc.node.Name)
+				}
+			}
+		})
+	}
+}
+
 func TestMarkDrain(t *testing.T) {
 	now := meta.Time{Time: time.Now()}
 	cases := []struct {
@@ -582,7 +674,7 @@ func TestMarkDrain(t *testing.T) {
 					},
 				},
 			},
-			drainStatus: DrainConditionStatus{Marked: true, LastTransition: now.Time},
+			drainStatus: DrainConditionStatus{Marked: true, FailedCount: 1, LastTransition: now.Time},
 			isErr:       false,
 		},
 		{
@@ -597,8 +689,7 @@ func TestMarkDrain(t *testing.T) {
 							LastHeartbeatTime:  now,
 							LastTransitionTime: now,
 							Reason:             "Draino",
-							Message:            "Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed: 2020-03-20T15:55:50+01:00",
-							//Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed: 2020-03-20T15:55:50+01:00
+							Message:            "[1] | Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed: 2020-03-20T15:55:50+01:00",
 						},
 					},
 				},
@@ -618,13 +709,32 @@ func TestMarkDrain(t *testing.T) {
 							LastHeartbeatTime:  now,
 							LastTransitionTime: now,
 							Reason:             "Draino",
-							Message:            "Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed(2): 2020-03-20T15:55:50+01:00",
-							//Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed(2): 2020-03-20T15:55:50+01:00
+							Message:            "[2] | Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed: 2020-03-20T15:55:50+01:00",
 						},
 					},
 				},
 			},
 			drainStatus: DrainConditionStatus{Marked: true, Completed: false, Failed: true, FailedCount: 2, LastTransition: now.Time},
+			isErr:       false,
+		},
+		{
+			name: "markDrain Failed(8)",
+			node: &core.Node{
+				ObjectMeta: meta.ObjectMeta{Name: nodeName},
+				Status: core.NodeStatus{
+					Conditions: []core.NodeCondition{
+						{
+							Type:               core.NodeConditionType(ConditionDrainedScheduled),
+							Status:             core.ConditionFalse,
+							LastHeartbeatTime:  now,
+							LastTransitionTime: now,
+							Reason:             "Draino",
+							Message:            "[8] | Drain activity scheduled 2020-03-20T15:50:34+01:00 | Failed: 2020-03-20T15:55:50+01:00",
+						},
+					},
+				},
+			},
+			drainStatus: DrainConditionStatus{Marked: true, Completed: false, Failed: true, FailedCount: 8, LastTransition: now.Time},
 			isErr:       false,
 		},
 	}
@@ -638,7 +748,7 @@ func TestMarkDrain(t *testing.T) {
 				if err != nil {
 					t.Errorf("node.Get(%v): %v", tc.node.Name, err)
 				}
-				drainStatus, err := IsMarkedForDrain(n)
+				drainStatus, err := GetDrainConditionStatus(n)
 				if drainStatus != tc.drainStatus {
 					t.Errorf("node %v initial drainStatus is not correct", tc.node.Name)
 				}
@@ -651,7 +761,7 @@ func TestMarkDrain(t *testing.T) {
 						if err != nil {
 							t.Errorf("node.Get(%v): %v", tc.node.Name, err)
 						}
-						if drainStatus, err = IsMarkedForDrain(n); !drainStatus.Marked {
+						if drainStatus, err = GetDrainConditionStatus(n); !drainStatus.Marked {
 							t.Errorf("node %v is not marked for drain", tc.node.Name)
 						}
 					}

--- a/internal/kubernetes/eventhandler_test.go
+++ b/internal/kubernetes/eventhandler_test.go
@@ -67,6 +67,10 @@ func (d *mockCordonDrainer) Drain(n *core.Node) error {
 	return nil
 }
 
+func (d *mockCordonDrainer) GetMaxDrainAttemptsBeforeFail() int32 {
+	return 0
+}
+
 func (d *mockCordonDrainer) MarkDrain(n *core.Node, when, finish time.Time, failed bool, failCount int32) error {
 	d.calls = append(d.calls, mockCall{
 		name: "MarkDrain",

--- a/internal/kubernetes/eventhandler_test.go
+++ b/internal/kubernetes/eventhandler_test.go
@@ -67,7 +67,7 @@ func (d *mockCordonDrainer) Drain(n *core.Node) error {
 	return nil
 }
 
-func (d *mockCordonDrainer) MarkDrain(n *core.Node, when, finish time.Time, failed bool) error {
+func (d *mockCordonDrainer) MarkDrain(n *core.Node, when, finish time.Time, failed bool, failCount int32) error {
 	d.calls = append(d.calls, mockCall{
 		name: "MarkDrain",
 		node: n.Name,
@@ -91,7 +91,7 @@ func (d *mockCordonDrainer) HasSchedule(node *core.Node) (has, failed bool) {
 	return false, false
 }
 
-func (d *mockCordonDrainer) Schedule(node *core.Node) (time.Time, error) {
+func (d *mockCordonDrainer) Schedule(node *core.Node, failedCount int32) (time.Time, error) {
 	d.calls = append(d.calls, mockCall{
 		name: "Schedule",
 		node: node.Name,

--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -441,7 +441,7 @@ func (s *DrainoConfigurationObserverImpl) hasPodThatMatchFilter(node *v1.Node, f
 }
 
 func getDrainStatusStr(node *v1.Node) string {
-	drainStatus, err := IsMarkedForDrain(node)
+	drainStatus, err := GetDrainConditionStatus(node)
 	if err != nil {
 		return "Error"
 	}


### PR DESCRIPTION
## Description
When a drain fails, it can be due to timeout or transient context.So far it is possible to ask for a retry by adding an annotation. To improve user and operational experience we should go for automatic retry (N times) before definitively failing. After failing N times the node is uncordoned and annotation is added:
```
draino/drain-retry: failed
```

This allows draino to continue draining other nodes, rather than being blocked at the cluster level.

## Implementation
- New flag *max-drain-attempts-before-fail* enables feature. May be an integer number of retries defaulting to 8.
- New check in EventHandler.HandleNode to fail when retry is exceeded with "Drain Failed: MaxDrainAttempts reached".
- Modifed SchedulesGroup.addSchedule to add backoff-delay on new retry schedules
- Modified APICordonDrainer.MarkDrain to encode retry count in the msgSuffix of the condition, and set annotation 'draino/drain-retry=failed' when/if retry count is exceeded.
- Added Makefile for new feature params
- Added testcases for MarkDrain

*NOTE on backoff delay* 
The delay is calculated in hours but is dependent on the fail attempts so far.
```
delay = 2 * failedCount * Hours 
# with max=8 we would get the sequence
#count: 1  2  3  4  5  6  7  8
#delay: 1  5 11 19 29 47 55 71
# where the 8th and final retry occurs 71hrs after the initial drain failure (or ~3days of failed retries).
```

Technically this is a geometrical backoff.

## Other Considerations
- metrics: the counter for drain-failure is incremented but there is no counter for final-drain-failure (implying retries happened)


## Example of a failed drain on a node
The following shows a node that failed 7x . Some info was removed for brevity.

```
Name:               ip-10-128-42-217.ec2.internal
Roles:              compute,echoserver
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=t2.medium
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=us-east-1
                    failure-domain.beta.kubernetes.io/zone=us-east-1b
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=ip-10-128-42-217
                    kubernetes.io/os=linux
                    node-role.kubernetes.io/compute=
                    node-role.kubernetes.io/echoserver=
                    nodegroups.datadoghq.com/cluster-autoscaler=true
                    nodegroups.datadoghq.com/local-storage=false
                    nodegroups.datadoghq.com/name=echoserver
                    nodegroups.datadoghq.com/namespace=datadog
Annotations:        draino/drain-retry: failed
                    io.cilium.network.ipv4-cilium-host: 10.130.147.2
                    io.cilium.network.ipv4-pod-cidr: 10.217.0.0/16
                    node-lifecycle.datadoghq.com/draino-configuration: standard
                    node.alpha.kubernetes.io/ttl: 0
                    nodegroups.datadoghq.com/event: done
                    volumes.kubernetes.io/controller-managed-attach-detach: true
CreationTimestamp:  Wed, 04 Aug 2021 10:54:47 -0400
Taints:             node=echoserver:NoSchedule
Unschedulable:      false
Lease:
  HolderIdentity:  ip-10-128-42-217.ec2.internal
  AcquireTime:     <unset>
  RenewTime:       Thu, 05 Aug 2021 00:17:55 -0400
Conditions:
  Type                 Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----                 ------  -----------------                 ------------------                ------                       -------
  NetworkUnavailable   False   Wed, 04 Aug 2021 10:56:04 -0400   Wed, 04 Aug 2021 10:56:04 -0400   CiliumIsUp                   Cilium is running on this node
  MemoryPressure       False   Thu, 05 Aug 2021 00:17:25 -0400   Wed, 04 Aug 2021 10:54:47 -0400   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure         False   Thu, 05 Aug 2021 00:17:25 -0400   Wed, 04 Aug 2021 10:54:47 -0400   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure          False   Thu, 05 Aug 2021 00:17:25 -0400   Wed, 04 Aug 2021 10:54:47 -0400   KubeletHasSufficientPID      kubelet has sufficient PID available
  Ready                True    Thu, 05 Aug 2021 00:17:25 -0400   Wed, 04 Aug 2021 10:56:07 -0400   KubeletReady                 kubelet is posting ready status. AppArmor enabled
  kubelet-update       True    Wed, 04 Aug 2021 17:51:25 -0400   Wed, 04 Aug 2021 17:51:25 -0400   NodeProblemDetector          Condition added with tooling
  DrainScheduled       False   Wed, 04 Aug 2021 19:10:39 -0400   Wed, 04 Aug 2021 17:51:25 -0400   Draino                       [7] | Drain activity scheduled 2021-08-04T19:10:39-04:00 | Failed: 2021-08-04T19:10:39-04:00
ProviderID:                   aws:///us-east-1b/i-05cc77041f7eda153
Non-terminated Pods:          (7 in total)
  Namespace                   Name                           CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
  ---------                   ----                           ------------  ----------  ---------------  -------------  ---
  cluster-cni                 cilium-agent-7jk2t             120m (6%)     120m (6%)   32Mi (0%)        2112Mi (63%)   13h
  cluster-dns-node-local      node-local-dns-hkbfn           50m (2%)      50m (2%)    64Mi (1%)        64Mi (1%)      13h
  datadog-agent               datadog-agent-l88zd-s4h2g      0 (0%)        950m (52%)  360Mi (10%)      2750Mi (82%)   13h
  datadog                     echoserver-6cfcd9f795-lkb7r    900m (50%)    900m (50%)  2000Mi (60%)     2000Mi (60%)   13h
  go-audit                    go-audit-h7xkh                 5m (0%)       7m (0%)     20Mi (0%)        30Mi (0%)      13h
  kube2iam                    kube2iam-2drpp                 10m (0%)      10m (0%)    64Mi (1%)        64Mi (1%)      13h
  node-monitoring             node-monitoring-vxvr4          50m (2%)      50m (2%)    128Mi (3%)       128Mi (3%)     13h
Events:
  Type     Reason              Age                   From     Message
  ----     ------              ----                  ----     -------
  Warning  DrainScheduled      6h26m                 draino   Will drain node after 2021-08-04T17:51:36.283448-04:00
  Warning  CordonSucceeded     6h26m                 draino   Cordoned node
  Normal   NodeNotSchedulable  6h26m                 kubelet  Node ip-10-128-42-217.ec2.internal status is now: NodeNotSchedulable
  Warning  DrainScheduled      5h29m                 draino   Will drain node after 2021-08-04T18:49:41.964612-04:00
  Warning  DrainScheduled      5h28m                 draino   Will drain node after 2021-08-04T18:51:53.566915-04:00
  Warning  DrainScheduled      5h26m                 draino   Will drain node after 2021-08-04T18:55:04.97127-04:00
  Warning  DrainScheduled      5h22m                 draino   Will drain node after 2021-08-04T18:59:16.421848-04:00
  Warning  DrainScheduled      5h18m                 draino   Will drain node after 2021-08-04T19:04:27.836007-04:00
  Warning  DrainScheduled      5h13m                 draino   Will drain node after 2021-08-04T19:10:39.248132-04:00
  Warning  DrainFailed         5h7m (x7 over 6h26m)  draino   Draining failed: cannot evict all pods: cannot evict pod datadog/echoserver-6cfcd9f795-lkb7r: This pod has more than one PodDisruptionBudget, which the eviction subresource does not support.
  Warning  DrainStarting       5h7m (x7 over 6h26m)  draino   Draining node
  Warning  DrainFailed         5h7m                  draino   Pod failed to Drain after multiple retries. Uncordoning node to free slot.
  Warning  UncordonStarting    5h7m                  draino   Uncordoning node
  Warning  UncordonSucceeded   5h7m                  draino   Uncordoned node
  Normal   NodeSchedulable     5h7m                  kubelet  Node ip-10-128-42-217.ec2.internal status is now: NodeSchedulable
```
