### PR TITLE
ensure that we are not blocking pod scheduling due to cordon on PVC/PV

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -212,12 +212,10 @@ func main() {
 	pods := kubernetes.NewPodWatch(cs)
 	statefulSets := kubernetes.NewStatefulsetWatch(cs)
 	persistentVolumes := kubernetes.NewPersistentVolumeWatch(cs)
-	persistentVolumeClaims := kubernetes.NewPersistentVolumeClaimWatch(cs)
 	runtimeObjectStoreImpl := &kubernetes.RuntimeObjectStoreImpl{
-		StatefulSetsStore:          statefulSets,
-		PodsStore:                  pods,
-		PersistentVolumeStore:      persistentVolumes,
-		PersistentVolumeClaimStore: persistentVolumeClaims,
+		StatefulSetsStore:     statefulSets,
+		PodsStore:             pods,
+		PersistentVolumeStore: persistentVolumes,
 	}
 
 	// Sanitize user input

--- a/internal/kubernetes/blocker.go
+++ b/internal/kubernetes/blocker.go
@@ -144,9 +144,10 @@ func (g *GlobalBlocksRunner) IsBlocked() (bool, string) {
 	return false, ""
 }
 
-func MaxNotReadyNodesCheckFunc(max int, percent bool, store RuntimeObjectStore) ComputeBlockStateFunction {
+func MaxNotReadyNodesCheckFunc(max int, percent bool, store RuntimeObjectStore, logger *zap.Logger) ComputeBlockStateFunction {
 	return func() bool {
 		if !store.HasSynced() {
+			logger.Warn("MaxNotReadyNodesCheckFunc: blocking due to informer not synched")
 			return true // better block till we know exactly the state of the system
 		}
 		if store.Nodes() == nil {
@@ -169,9 +170,10 @@ func MaxNotReadyNodesCheckFunc(max int, percent bool, store RuntimeObjectStore) 
 	}
 }
 
-func MaxPendingPodsCheckFunc(max int, percent bool, store RuntimeObjectStore) ComputeBlockStateFunction {
+func MaxPendingPodsCheckFunc(max int, percent bool, store RuntimeObjectStore, logger *zap.Logger) ComputeBlockStateFunction {
 	return func() bool {
 		if !store.HasSynced() {
+			logger.Warn("MaxPendingPodsCheckFunc: blocking due to informer not synched")
 			return true // better block till we know exactly the state of the system
 		}
 		if store.Pods() == nil {

--- a/internal/kubernetes/conditions_test.go
+++ b/internal/kubernetes/conditions_test.go
@@ -138,7 +138,7 @@ func TestOffendingConditions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewDrainingResourceEventHandler(&NoopCordonDrainer{}, &record.FakeRecorder{}, WithConditionsFilter(tc.conditions))
+			h := NewDrainingResourceEventHandler(&NoopCordonDrainer{}, nil, &record.FakeRecorder{}, WithConditionsFilter(tc.conditions))
 			badConditions := GetNodeOffendingConditions(tc.obj, h.conditions)
 			if !reflect.DeepEqual(badConditions, tc.expected) {
 				t.Errorf("offendingConditions(tc.obj): want %#v, got %#v", tc.expected, badConditions)

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -293,12 +293,12 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 	// First cordon the node if it is not yet cordoned
 	if !n.Spec.Unschedulable {
 		// Check if the node is not needed due to a local PV and a pending pod trying to land on that node
-		podsWithPVCBoundToThatNode,err:=GetPodsBoundToNodeByPV(n.Name,h.objectsStore)
+		podsWithPVCBoundToThatNode, err := GetPodsBoundToNodeByPV(n.Name, h.objectsStore)
 		if err != nil {
 			logger.Error(err.Error())
 			return
 		}
-		if len(podsWithPVCBoundToThatNode)>0 {
+		if len(podsWithPVCBoundToThatNode) > 0 {
 			LogForVerboseNode(logger, n, "Cordon Skip: Pod"+podsWithPVCBoundToThatNode[0].ResourceVersion+" need to be scheduled on node")
 			nr := &core.ObjectReference{Kind: "Node", Name: n.GetName(), UID: types.UID(n.GetName())}
 			h.eventRecorder.Event(nr, core.EventTypeWarning, eventReasonUncordonDueToPendingPodWithLocalPV, "Pod "+podsWithPVCBoundToThatNode[0].Name+" needs that node due to local PV. Not cordoning the node.")

--- a/internal/kubernetes/limiter_test.go
+++ b/internal/kubernetes/limiter_test.go
@@ -416,7 +416,7 @@ func TestLimiter_CanCordon(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var objects []runtime.Object
-			for _,n:=range NodesMapAsSlice(){
+			for _, n := range NodesMapAsSlice() {
 				objects = append(objects, n)
 			}
 			kclient := fake.NewSimpleClientset(objects...)
@@ -593,10 +593,10 @@ func TestPodLimiter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var objects []runtime.Object
-			for _,p:=range tt.pods{
+			for _, p := range tt.pods {
 				objects = append(objects, p)
 			}
-			for _,n:=range tt.nodes{
+			for _, n := range tt.nodes {
 				objects = append(objects, n)
 			}
 			kclient := fake.NewSimpleClientset(objects...)

--- a/internal/kubernetes/limiter_test.go
+++ b/internal/kubernetes/limiter_test.go
@@ -11,6 +11,8 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/flowcontrol"
 )
 
@@ -87,7 +89,7 @@ var nodesTestMap = map[string]*core.Node{
 	},
 	"ABC": &core.Node{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "ABC-cordon",
+			Name: "ABC",
 			Labels: map[string]string{
 				"A": "A", "B": "B", "C": "C",
 			},
@@ -105,7 +107,7 @@ var nodesTestMap = map[string]*core.Node{
 	},
 	"ABC-Cordon": &core.Node{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "AB-cordon",
+			Name: "ABC-cordon",
 			Labels: map[string]string{
 				"A": "A", "B": "B", "C": "C",
 			},
@@ -178,46 +180,6 @@ func NodesMapAsSlice() []*core.Node {
 	}
 	return list
 }
-
-type testNodeLister struct{}
-
-func (t *testNodeLister) ListNodes() []*core.Node {
-	return NodesMapAsSlice()
-}
-
-type testNodestore struct{}
-
-func (f testNodestore) HasSynced() bool                     { return true }
-func (f testNodestore) Get(name string) (*core.Node, error) { return nil, nil }
-func (f testNodestore) ListNodes() []*core.Node {
-	return NodesMapAsSlice()
-}
-
-var nodeStore = &testNodestore{}
-
-type testPodstore struct{}
-
-var podStore = &testPodstore{}
-
-func (f testPodstore) HasSynced() bool { return true }
-func (f testPodstore) ListPodsForNode(nodeName string) ([]*core.Pod, error) {
-	return pods, nil
-}
-func (f testPodstore) ListPodsByStatus(podStatus string) ([]*core.Pod, error) {
-	return pods, nil
-}
-func (f testPodstore) GetPodCount() (int, error) {
-	return len(pods), nil
-}
-
-type testRuntimeObjectStore struct{}
-
-func (r *testRuntimeObjectStore) Nodes() NodeStore               { return nodeStore }
-func (r *testRuntimeObjectStore) Pods() PodStore                 { return podStore }
-func (r *testRuntimeObjectStore) StatefulSets() StatefulSetStore { return nil }
-func (r *testRuntimeObjectStore) HasSynced() bool                { return true }
-
-var runtimeObjectStore = &testRuntimeObjectStore{}
 
 func Test_getMatchingNodesForTaintCount(t *testing.T) {
 	tests := []struct {
@@ -323,7 +285,7 @@ func TestLimiter_CanCordon(t *testing.T) {
 	maxNotReadyNodePeriod := DefaultMaxNotReadyNodesPeriod
 	tests := []struct {
 		name                 string
-		globalBlockerBuilder func() GlobalBlocker
+		globalBlockerBuilder func(sotre RuntimeObjectStore) GlobalBlocker
 		limiterfuncs         map[string]LimiterFunc
 		node                 *core.Node
 		want                 bool
@@ -405,9 +367,9 @@ func TestLimiter_CanCordon(t *testing.T) {
 		{
 			name: "limit on 15% of nodes NotReady with threshold at max=10%", // 15% = 1/7 nodes
 			node: nodesTestMap["D"],
-			globalBlockerBuilder: func() GlobalBlocker {
+			globalBlockerBuilder: func(store RuntimeObjectStore) GlobalBlocker {
 				g := NewGlobalBlocker(zap.NewNop())
-				g.AddBlocker("limiter-notReady-10%", MaxNotReadyNodesCheckFunc(10, true, runtimeObjectStore), maxNotReadyNodePeriod)
+				g.AddBlocker("limiter-notReady-10%", MaxNotReadyNodesCheckFunc(10, true, store), maxNotReadyNodePeriod)
 				g.blockers[0].updateBlockState()
 				return g
 			},
@@ -417,9 +379,9 @@ func TestLimiter_CanCordon(t *testing.T) {
 		{
 			name: "limit on 1 nodes NotReady with threshold at max=1",
 			node: nodesTestMap["D"],
-			globalBlockerBuilder: func() GlobalBlocker {
+			globalBlockerBuilder: func(store RuntimeObjectStore) GlobalBlocker {
 				g := NewGlobalBlocker(zap.NewNop())
-				g.AddBlocker("limiter-notReady-1", MaxNotReadyNodesCheckFunc(1, false, runtimeObjectStore), maxNotReadyNodePeriod)
+				g.AddBlocker("limiter-notReady-1", MaxNotReadyNodesCheckFunc(1, false, store), maxNotReadyNodePeriod)
 				g.blockers[0].updateBlockState()
 				return g
 			},
@@ -429,9 +391,9 @@ func TestLimiter_CanCordon(t *testing.T) {
 		{
 			name: "no limit on 15% nodes NotReady with threshold max=20%",
 			node: nodesTestMap["D"],
-			globalBlockerBuilder: func() GlobalBlocker {
+			globalBlockerBuilder: func(store RuntimeObjectStore) GlobalBlocker {
 				g := NewGlobalBlocker(zap.NewNop())
-				g.AddBlocker("no-limiter-notReady-20%", MaxNotReadyNodesCheckFunc(20, true, runtimeObjectStore), maxNotReadyNodePeriod)
+				g.AddBlocker("no-limiter-notReady-20%", MaxNotReadyNodesCheckFunc(20, true, store), maxNotReadyNodePeriod)
 				g.blockers[0].updateBlockState()
 				return g
 			},
@@ -441,9 +403,9 @@ func TestLimiter_CanCordon(t *testing.T) {
 		{
 			name: "no limit on 1 nodes NotReady with threshold max=20",
 			node: nodesTestMap["D"],
-			globalBlockerBuilder: func() GlobalBlocker {
+			globalBlockerBuilder: func(store RuntimeObjectStore) GlobalBlocker {
 				g := NewGlobalBlocker(zap.NewNop())
-				g.AddBlocker("no-limiter-notReady-20", MaxNotReadyNodesCheckFunc(20, false, runtimeObjectStore), maxNotReadyNodePeriod)
+				g.AddBlocker("no-limiter-notReady-20", MaxNotReadyNodesCheckFunc(20, false, store), maxNotReadyNodePeriod)
 				g.blockers[0].updateBlockState()
 				return g
 			},
@@ -453,16 +415,23 @@ func TestLimiter_CanCordon(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var objects []runtime.Object
+			for _,n:=range NodesMapAsSlice(){
+				objects = append(objects, n)
+			}
+			kclient := fake.NewSimpleClientset(objects...)
+			store, closeCh := RunStoreForTest(kclient)
+			defer closeCh()
 			l := &Limiter{
 				logger:      zap.NewNop(),
 				rateLimiter: flowcontrol.NewTokenBucketRateLimiter(200, 200),
 			}
-			l.SetNodeLister(&testNodeLister{})
+			l.SetNodeLister(store.Nodes())
 			for k, v := range tt.limiterfuncs {
 				l.AddLimiter(k, v)
 			}
 			if tt.globalBlockerBuilder != nil {
-				gl := tt.globalBlockerBuilder()
+				gl := tt.globalBlockerBuilder(store)
 				for name, blockStateFunc := range gl.GetBlockStateCacheAccessor() {
 					localFunc := blockStateFunc
 					l.AddLimiter(name, func(_ *core.Node, _, _ []*core.Node) (bool, error) { return !localFunc(), nil })
@@ -592,7 +561,7 @@ func TestPodLimiter(t *testing.T) {
 	maxNotReadyNodePeriod := DefaultMaxNotReadyNodesPeriod
 	tests := []struct {
 		name                 string
-		globalBlockerBuilder func() GlobalBlocker
+		globalBlockerBuilder func(store RuntimeObjectStore) GlobalBlocker
 		limiterfuncs         map[string]LimiterFunc
 		nodes                []*core.Node
 		pods                 []*core.Pod
@@ -610,9 +579,9 @@ func TestPodLimiter(t *testing.T) {
 			name:  "limit on 1 pending pods with threshold at max=1",
 			nodes: NodesMapAsSlice(),
 			pods:  pods,
-			globalBlockerBuilder: func() GlobalBlocker {
+			globalBlockerBuilder: func(store RuntimeObjectStore) GlobalBlocker {
 				g := NewGlobalBlocker(zap.NewNop())
-				g.AddBlocker("limiter-pending-pods-1", MaxPendingPodsCheckFunc(1, false, runtimeObjectStore), maxNotReadyNodePeriod)
+				g.AddBlocker("limiter-pending-pods-1", MaxPendingPodsCheckFunc(1, false, store), maxNotReadyNodePeriod)
 				g.blockers[0].updateBlockState()
 				return g
 			},
@@ -623,16 +592,27 @@ func TestPodLimiter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var objects []runtime.Object
+			for _,p:=range tt.pods{
+				objects = append(objects, p)
+			}
+			for _,n:=range tt.nodes{
+				objects = append(objects, n)
+			}
+			kclient := fake.NewSimpleClientset(objects...)
+			store, closeCh := RunStoreForTest(kclient)
+			defer closeCh()
+
 			l := &Limiter{
 				logger:      zap.NewNop(),
 				rateLimiter: flowcontrol.NewTokenBucketRateLimiter(200, 200),
 			}
-			l.SetNodeLister(&testNodeLister{})
+			l.SetNodeLister(store.Nodes())
 			for k, v := range tt.limiterfuncs {
 				l.AddLimiter(k, v)
 			}
 			if tt.globalBlockerBuilder != nil {
-				gl := tt.globalBlockerBuilder()
+				gl := tt.globalBlockerBuilder(store)
 				for name, blockStateFunc := range gl.GetBlockStateCacheAccessor() {
 					localFunc := blockStateFunc
 					l.AddLimiter(name, func(_ *core.Node, _, _ []*core.Node) (bool, error) { return !localFunc(), nil })

--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -178,12 +178,10 @@ func (s *DrainoConfigurationObserverImpl) Run(stop <-chan struct{}) {
 //       There is no other way around I could find for the moment to cleanup old series. The concurrency risk is clearly acceptable if we look at the frequency of metric poll versus the frequency and a speed of metric generation.
 //       In worst case the server will be missing series for a given scrape (not even report a bad value, just missing series). So the impact if it happens is insignificant.
 func (s *DrainoConfigurationObserverImpl) updateGauges(metrics inScopeMetrics) {
-	s.logger.Info("updating gauges")
 	if err := s.metricsObjects.reset(); err != nil {
 		s.logger.Error("Unable to purger previous metrics series")
 		return
 	}
-	s.logger.Info("reset gauges done")
 	for tagsValues, count := range metrics {
 		// This list of tags must be in sync with the list of tags in the function metricsObjectsForObserver::reset()
 		allTags, _ := tag.New(context.Background(),
@@ -201,7 +199,6 @@ func (s *DrainoConfigurationObserverImpl) updateGauges(metrics inScopeMetrics) {
 			tag.Upsert(TagUserOptOutViaPodAnnotation, strconv.FormatBool(tagsValues.UserOptOutViaPodAnnotation)))
 		stats.Record(allTags, s.metricsObjects.MeasureNodesWithNodeOptions.M(count))
 	}
-	s.logger.Info("metrics gauges done")
 }
 
 func (s *DrainoConfigurationObserverImpl) addNodeToQueue(node *v1.Node) {


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/COMPUTE-1350

TLDR: concurrency case between `draino` and rollout of STS. The pod is `pending` and can't be scheduled because `draino` has cordoned the node holding the PV while the pod was recreated. When we discover that context we uncordon the node.

In order to achieve this the runtimeObjectSotre was augmented with PV and PVC + pod has now a reverse index on PVC