### PR TITLE
new strategy for scheduling retries

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -55,17 +55,18 @@ func main() {
 	var (
 		app = kingpin.New(filepath.Base(os.Args[0]), "Automatically cordons and drains nodes that match the supplied conditions.").DefaultEnvars()
 
-		debug            = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-		listen           = app.Flag("listen", "Address at which to expose /metrics and /healthz.").Default(":10002").String()
-		kubecfg          = app.Flag("kubeconfig", "Path to kubeconfig file. Leave unset to use in-cluster config.").String()
-		apiserver        = app.Flag("master", "Address of Kubernetes API server. Leave unset to use in-cluster config.").String()
-		dryRun           = app.Flag("dry-run", "Emit an event without cordoning or draining matching nodes.").Bool()
-		maxGracePeriod   = app.Flag("max-grace-period", "Maximum time evicted pods will be given to terminate gracefully.").Default(kubernetes.DefaultMaxGracePeriod.String()).Duration()
-		evictionHeadroom = app.Flag("eviction-headroom", "Additional time to wait after a pod's termination grace period for it to have been deleted.").Default(kubernetes.DefaultEvictionOverhead.String()).Duration()
-		drainBuffer      = app.Flag("drain-buffer", "Minimum time between starting each drain. Nodes are always cordoned immediately.").Default(kubernetes.DefaultDrainBuffer.String()).Duration()
-		nodeLabels       = app.Flag("node-label", "(Deprecated) Nodes with this label will be eligible for cordoning and draining. May be specified multiple times").Strings()
-		nodeLabelsExpr   = app.Flag("node-label-expr", "Nodes that match this expression will be eligible for cordoning and draining.").String()
-		namespace        = app.Flag("namespace", "Namespace used to create leader election lock object.").Default("kube-system").String()
+		debug                       = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		listen                      = app.Flag("listen", "Address at which to expose /metrics and /healthz.").Default(":10002").String()
+		kubecfg                     = app.Flag("kubeconfig", "Path to kubeconfig file. Leave unset to use in-cluster config.").String()
+		apiserver                   = app.Flag("master", "Address of Kubernetes API server. Leave unset to use in-cluster config.").String()
+		dryRun                      = app.Flag("dry-run", "Emit an event without cordoning or draining matching nodes.").Bool()
+		maxGracePeriod              = app.Flag("max-grace-period", "Maximum time evicted pods will be given to terminate gracefully.").Default(kubernetes.DefaultMaxGracePeriod.String()).Duration()
+		evictionHeadroom            = app.Flag("eviction-headroom", "Additional time to wait after a pod's termination grace period for it to have been deleted.").Default(kubernetes.DefaultEvictionOverhead.String()).Duration()
+		drainBuffer                 = app.Flag("drain-buffer", "Minimum time between starting each drain. Nodes are always cordoned immediately.").Default(kubernetes.DefaultDrainBuffer.String()).Duration()
+		schedulingRetryBackoffDelay = app.Flag("retry-backoff-delay", "Additional delay to add between retry schedules.").Default(kubernetes.DefaultSchedulingRetryBackoffDelay.String()).Duration()
+		nodeLabels                  = app.Flag("node-label", "(Deprecated) Nodes with this label will be eligible for cordoning and draining. May be specified multiple times").Strings()
+		nodeLabelsExpr              = app.Flag("node-label-expr", "Nodes that match this expression will be eligible for cordoning and draining.").String()
+		namespace                   = app.Flag("namespace", "Namespace used to create leader election lock object.").Default("kube-system").String()
 
 		leaderElectionLeaseDuration = app.Flag("leader-election-lease-duration", "Lease duration for leader election.").Default(DefaultLeaderElectionLeaseDuration.String()).Duration()
 		leaderElectionRenewDeadline = app.Flag("leader-election-renew-deadline", "Leader election renew deadline.").Default(DefaultLeaderElectionRenewDeadline.String()).Duration()
@@ -336,6 +337,7 @@ func main() {
 		eventRecorder,
 		kubernetes.WithLogger(log),
 		kubernetes.WithDrainBuffer(*drainBuffer),
+		kubernetes.WithSchedulingBackoffDelay(*schedulingRetryBackoffDelay),
 		kubernetes.WithDurationWithCompletedStatusBeforeReplacement(*durationBeforeReplacement),
 		kubernetes.WithDrainGroups(*drainGroupLabelKey),
 		kubernetes.WithConditionsFilter(*conditions),
@@ -351,6 +353,7 @@ func main() {
 				eventRecorder,
 				kubernetes.WithLogger(log),
 				kubernetes.WithDrainBuffer(*drainBuffer),
+				kubernetes.WithSchedulingBackoffDelay(*schedulingRetryBackoffDelay),
 				kubernetes.WithDurationWithCompletedStatusBeforeReplacement(*durationBeforeReplacement),
 				kubernetes.WithDrainGroups(*drainGroupLabelKey),
 				kubernetes.WithGlobalBlocking(globalLocker),


### PR DESCRIPTION
Following first usage of automatic retry, I met the problem that is described in that comment in previous PR:
https://github.com/DataDog/draino/pull/36/files#r677379037

Now the for the same group we consider the nodes with retry and the nodes without retry to compute next schedule time.

Also the scheduling every 2 hours is a bit too slow, reducing it to 23 minutes. It is possible to override this value of 23 by adding a specific annotation on the node `draino/retry-delay` with the value as duration.