### PR TITLE
Use draino configuration value of out of scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# This dockerfile is used for testing, at release time, compute delivery uses its own Dockerfile
 FROM golang:1.13.15-alpine3.11 AS build
 
 RUN apk update && apk add git && apk add curl
@@ -13,3 +14,4 @@ RUN apk update && apk add ca-certificates
 RUN addgroup -S user && adduser -S user -G user
 USER user
 COPY --from=build /draino /draino
+ENV PATH="/:${PATH}"

--- a/internal/kubernetes/limiter_test.go
+++ b/internal/kubernetes/limiter_test.go
@@ -565,15 +565,15 @@ func TestPodLimiter(t *testing.T) {
 		limiterfuncs         map[string]LimiterFunc
 		nodes                []*core.Node
 		pods                 []*core.Pod
-		want                 bool
-		want1                string
+		wantCanCordon        bool
+		wantReason           string
 	}{
 		{
-			name:  "not limited",
-			nodes: NodesMapAsSlice(),
-			pods:  pods,
-			want:  true,
-			want1: "",
+			name:          "not limited",
+			nodes:         NodesMapAsSlice(),
+			pods:          pods,
+			wantCanCordon: true,
+			wantReason:    "",
 		},
 		{
 			name:  "limit on 1 pending pods with threshold at max=1",
@@ -585,8 +585,8 @@ func TestPodLimiter(t *testing.T) {
 				g.blockers[0].updateBlockState()
 				return g
 			},
-			want:  false,
-			want1: "limiter-pending-pods-1",
+			wantCanCordon: false,
+			wantReason:    "limiter-pending-pods-1",
 		},
 	}
 
@@ -619,12 +619,12 @@ func TestPodLimiter(t *testing.T) {
 				}
 			}
 			time.Sleep(2 * maxNotReadyNodePeriod) // wait for the caches to update
-			got, got1 := l.CanCordon(tt.nodes[0])
-			if got != tt.want {
-				t.Errorf("CanCordon() got = %v, want %v", got, tt.want)
+			gotCanCordon, gotReason := l.CanCordon(tt.nodes[0])
+			if gotCanCordon != tt.wantCanCordon {
+				t.Errorf("CanCordon() got = %v, want %v", gotCanCordon, tt.wantCanCordon)
 			}
-			if got1 != tt.want1 {
-				t.Errorf("CanCordon() got1 = %v, want %v", got1, tt.want1)
+			if gotReason != tt.wantReason {
+				t.Errorf("CanCordon() got1 = %v, want %v", gotReason, tt.wantReason)
 			}
 		})
 	}

--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ import (
 
 const (
 	ConfigurationAnnotationKey = "node-lifecycle.datadoghq.com/draino-configuration"
+	OutOfScopeAnnotationValue  = "out-of-scope"
 	nodeOptionsMetricName      = "node_options_nodes_total"
 )
 
@@ -135,7 +137,10 @@ func (s *DrainoConfigurationObserverImpl) Run(stop <-chan struct{}) {
 		case <-ticker.C:
 			// Let's update the nodes metadata
 			for _, node := range s.runtimeObjectStore.Nodes().ListNodes() {
-				if s.IsAnnotationUpdateNeeded(node) {
+				_, outOfDate, err := s.getAnnotationUpdate(node)
+				if err != nil {
+					s.logger.Error("Failed to check if config annotation was out of date", zap.Error(err), zap.String("node", node.Name))
+				} else if outOfDate {
 					s.addNodeToQueue(node)
 				}
 			}
@@ -148,9 +153,10 @@ func (s *DrainoConfigurationObserverImpl) Run(stop <-chan struct{}) {
 					node.Annotations = map[string]string{}
 				}
 				t := inScopeTags{
-					NodeTagsValues:                  nodeTags,
-					DrainStatus:                     getDrainStatusStr(node),
-					InScope:                         len(node.Annotations[ConfigurationAnnotationKey]) > 0,
+					NodeTagsValues: nodeTags,
+					DrainStatus:    getDrainStatusStr(node),
+					// TODO delete empty string check once out of scope value has gone to all applicable nodes' annotation value in the fleet
+					InScope:                         len(node.Annotations[ConfigurationAnnotationKey]) > 0 || node.Annotations[ConfigurationAnnotationKey] == OutOfScopeAnnotationValue,
 					PreprovisioningEnabled:          node.Annotations[preprovisioningAnnotationKey] == preprovisioningAnnotationValue,
 					PVCManagementEnabled:            s.HasPodWithPVCManagementEnabled(node),
 					DrainRetry:                      HasDrainRetryAnnotation(node),
@@ -206,28 +212,33 @@ func (s *DrainoConfigurationObserverImpl) addNodeToQueue(node *v1.Node) {
 	s.queueNodeToBeUpdated.AddRateLimited(node.Name)
 }
 
-func (s *DrainoConfigurationObserverImpl) IsAnnotationUpdateNeeded(node *v1.Node) bool {
-	configs := strings.Split(node.Annotations[ConfigurationAnnotationKey], ",")
+// getAnnotationUpdate returns the annotation value the node should have and whether or not the annotation value is currently out of date (not equal to first return value)
+func (s *DrainoConfigurationObserverImpl) getAnnotationUpdate(node *v1.Node) (string, bool, error) {
+	valueOriginal := node.Annotations[ConfigurationAnnotationKey]
+	configsOriginal := strings.Split(valueOriginal, ",")
+	var configs []string
+	for _, config := range configsOriginal {
+		// TODO delete empty string check once out of scope value has gone to all applicable nodes' annotation value in the fleet
+		if config == "" || config == OutOfScopeAnnotationValue || config == s.configName {
+			continue
+		}
+		configs = append(configs, config)
+	}
 	inScope, reason, err := s.IsInScope(node)
 	if err != nil {
-		s.logger.Error("Can't check if node is in scope", zap.Error(err), zap.String("node", node.Name))
-		return false
+		return "", false, err
 	}
 	LogForVerboseNode(s.logger, node, "InScope information", zap.Bool("inScope", inScope), zap.String("reason", reason))
 	if inScope {
-		for _, c := range configs {
-			if c == s.configName {
-				return false
-			}
-		}
-		return true
+		configs = append(configs, s.configName)
 	}
-	for _, c := range configs {
-		if c == s.configName {
-			return true
-		}
+	if len(configs) == 0 {
+		// add out of scope value for user visibility
+		configs = append(configs, OutOfScopeAnnotationValue)
 	}
-	return false
+	sort.Strings(configs)
+	valueDesired := strings.Join(configs, ",")
+	return valueDesired, valueDesired != valueOriginal, nil
 }
 
 // IsInScope return if the node is in scope of the running configuration. If not it also return the reason for not being in scope.
@@ -296,48 +307,16 @@ func (s *DrainoConfigurationObserverImpl) updateNodeAnnotations(nodeName string)
 		}
 		return err
 	}
-	var configs []string
-	configsFromAnnotation := strings.Split(node.Annotations[ConfigurationAnnotationKey], ",")
-	for _, c := range configsFromAnnotation {
-		if c == "" { // remove empty annotation that reflect no scope.
-			continue
-		}
-		configs = append(configs, c)
-	}
-	initialConfigCount := len(configs)
-
-	inScope, _, err := s.IsInScope(node)
+	desiredValue, outOfDate, err := s.getAnnotationUpdate(node)
 	if err != nil {
-		s.logger.Error("Can't check if node is in scope", zap.Error(err), zap.String("node", node.Name))
 		return err
 	}
-	if inScope {
-		found := false
-		for _, c := range configs {
-			if c == s.configName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			configs = append(configs, s.configName)
-		}
-	} else {
-		toKeep := []string{}
-		for _, c := range configs {
-			if c != s.configName {
-				toKeep = append(toKeep, c)
-			}
-		}
-		configs = toKeep
-	}
 
-	if len(configs) != initialConfigCount {
-		newConfig := strings.Join(configs, ",")
+	if outOfDate {
 		if node.Annotations == nil {
 			node.Annotations = map[string]string{}
 		}
-		return PatchNodeAnnotationKey(s.kclient, nodeName, ConfigurationAnnotationKey, newConfig)
+		return PatchNodeAnnotationKey(s.kclient, nodeName, ConfigurationAnnotationKey, desiredValue)
 	}
 	return nil
 }

--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -153,10 +153,9 @@ func (s *DrainoConfigurationObserverImpl) Run(stop <-chan struct{}) {
 					node.Annotations = map[string]string{}
 				}
 				t := inScopeTags{
-					NodeTagsValues: nodeTags,
-					DrainStatus:    getDrainStatusStr(node),
-					// TODO delete empty string check once out of scope value has gone to all applicable nodes' annotation value in the fleet
-					InScope:                         len(node.Annotations[ConfigurationAnnotationKey]) > 0 || node.Annotations[ConfigurationAnnotationKey] == OutOfScopeAnnotationValue,
+					NodeTagsValues:                  nodeTags,
+					DrainStatus:                     getDrainStatusStr(node),
+					InScope:                         len(node.Annotations[ConfigurationAnnotationKey]) > 0 || node.Annotations[ConfigurationAnnotationKey] != OutOfScopeAnnotationValue,
 					PreprovisioningEnabled:          node.Annotations[preprovisioningAnnotationKey] == preprovisioningAnnotationValue,
 					PVCManagementEnabled:            s.HasPodWithPVCManagementEnabled(node),
 					DrainRetry:                      HasDrainRetryAnnotation(node),


### PR DESCRIPTION
Hopefully this will make it more clear to users when a node is out of
scope instead of just having the value of the annotation be empty

for https://datadoghq.atlassian.net/browse/COMPUTE-997