### PR TITLE
remove drain schedule if a node is not cordon + do not drain if not cordon

### DIFF
--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -98,6 +98,15 @@ func (e NodePreprovisioningTimeoutError) Error() string {
 	return "timed out waiting for node pre-provisioning"
 }
 
+type NodeIsNotCordonError struct {
+	NodeName string
+}
+
+func (e NodeIsNotCordonError) Error() string {
+	return "the node "+e.NodeName+" is not cordoned"
+}
+
+
 type PodEvictionTimeoutError struct {
 }
 
@@ -589,7 +598,8 @@ func (d *APICordonDrainer) Drain(node *core.Node) error {
 	}
 
 	if !n.Spec.Unschedulable {
-		LoggerForNode(node, d.l).Info("Aborting drain because the node is not cordon")
+		LoggerForNode(node, d.l).Info("Aborting drain because the node is not cordoned")
+		return NodeIsNotCordonError{NodeName:node.Name}
 	}
 
 	pods, err := d.GetPodsToDrain(n.GetName(), nil)

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -293,10 +293,9 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 	// If the node was uncordoned (by user or other system) but it still has a schedule we should remove the schedule
 	if !n.Spec.Unschedulable && drainStatus.Marked {
 		hasSchedule, _ := h.drainScheduler.HasSchedule(n)
-		if hasSchedule && (!drainStatus.Completed || !drainStatus.Failed) {
-			logger.Info("Removing schedule for the node that is not cordon")
-			nr := &core.ObjectReference{Kind: "Node", Name: n.Name, UID: types.UID(n.Name)}
-			h.eventRecorder.Event(nr, core.EventTypeNormal, eventReasonDrainScheduleDeleted, "Deleting schedule because the node was not cordon.")
+		if hasSchedule && (!drainStatus.Completed && !drainStatus.Failed) {
+			logger.Info("Removing schedule for the node that is not cordoned")
+			h.eventRecorder.NodeEventf(n, core.EventTypeNormal, eventReasonDrainScheduleDeleted, "Deleting schedule because the node was not cordoned")
 			h.drainScheduler.DeleteSchedule(n)
 			return
 		}

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -49,6 +49,7 @@ const (
 	eventReasonUncordonDueToPendingPodWithLocalPV = "PodBoundToNodeViaLocalPV"
 
 	eventReasonDrainScheduled        = "DrainScheduled"
+	eventReasonDrainScheduleDeleted  = "DrainScheduleDeleted"
 	eventReasonDrainSchedulingFailed = "DrainSchedulingFailed"
 	eventReasonDrainStarting         = "DrainStarting"
 	eventReasonDrainSucceeded        = "DrainSucceeded"
@@ -257,6 +258,18 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 		h.logger.Warn("Waiting informer to sync")
 		return
 	}
+
+	drainStatus, err := GetDrainConditionStatus(n)
+	if err != nil {
+		logger.Error(err.Error())
+		return
+	}
+	LogForVerboseNode(h.logger, n, "drainStatus",
+		zap.Bool("marked", drainStatus.Marked),
+		zap.Bool("completed", drainStatus.Completed),
+		zap.Bool("failed", drainStatus.Failed),
+		zap.Error(err))
+
 	// If the node is already cordon we may need to check if it should be uncordon, in case:
 	// - no more bad condition
 	// - it is cordon but still hold a PV needed by a pod that is pending schedule
@@ -275,6 +288,18 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 			return
 		}
 		LogForVerboseNode(h.logger, n, "Not uncordoning")
+	}
+
+	// If the node was uncordoned (by user or other system) but it still has a schedule we should remove the schedule
+	if !n.Spec.Unschedulable && drainStatus.Marked {
+		hasSchedule, _ := h.drainScheduler.HasSchedule(n)
+		if hasSchedule && (!drainStatus.Completed || !drainStatus.Failed) {
+			logger.Info("Removing schedule for the node that is not cordon")
+			nr := &core.ObjectReference{Kind: "Node", Name: n.Name, UID: types.UID(n.Name)}
+			h.eventRecorder.Event(nr, core.EventTypeNormal, eventReasonDrainScheduleDeleted, "Deleting schedule because the node was not cordon.")
+			h.drainScheduler.DeleteSchedule(n)
+			return
+		}
 	}
 
 	if HasDrainRetryFailedAnnotation(n) {
@@ -354,17 +379,6 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 		logger.Error(err.Error())
 		return
 	}
-
-	drainStatus, err := GetDrainConditionStatus(n)
-	if err != nil {
-		logger.Error(err.Error())
-		return
-	}
-	LogForVerboseNode(h.logger, n, "drainStatus",
-		zap.Bool("marked", drainStatus.Marked),
-		zap.Bool("completed", drainStatus.Completed),
-		zap.Bool("failed", drainStatus.Failed),
-		zap.Error(err))
 
 	// Check if empty node is blocked due to minSize. If yes request a node replacement
 	if len(pods) == 0 && drainStatus.Completed {

--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -380,10 +380,17 @@ func (s *DrainoConfigurationObserverImpl) HasPodWithPVCManagementEnabled(node *v
 		return false
 	}
 	for _, p := range pods {
-		valAnnotation, _ := GetAnnotationFromPodOrController(PVCStorageClassCleanupAnnotationKey, p, s.runtimeObjectStore)
-		if valAnnotation == PVCStorageClassCleanupAnnotationValue {
+		if PVCStorageClassCleanupEnabled(p, s.runtimeObjectStore) {
 			return true
 		}
+	}
+	return false
+}
+
+func PVCStorageClassCleanupEnabled(p *v1.Pod, store RuntimeObjectStore) bool {
+	valAnnotation, _ := GetAnnotationFromPodOrController(PVCStorageClassCleanupAnnotationKey, p, store)
+	if valAnnotation == PVCStorageClassCleanupAnnotationValue {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
Three changes in that PR:
1 - If the user uncordon a node we should remove any existing schedule.
2 -If a drain start we should verify that the node is still cordon.
3- In GetUnscheduledPodsBoundToNodeByPV do not take into account fresh pending pods: the PVC cleanup might be ongoing... so let's give it chance to heppen.