### PR TITLE
Centralize all event creation

### DIFF
--- a/internal/kubernetes/conditions_test.go
+++ b/internal/kubernetes/conditions_test.go
@@ -139,7 +139,7 @@ func TestOffendingConditions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewDrainingResourceEventHandler(fake.NewSimpleClientset(), &NoopCordonDrainer{}, nil, &record.FakeRecorder{}, WithConditionsFilter(tc.conditions))
+			h := NewDrainingResourceEventHandler(fake.NewSimpleClientset(), &NoopCordonDrainer{}, nil, NewEventRecorder(&record.FakeRecorder{}), WithConditionsFilter(tc.conditions))
 			badConditions := GetNodeOffendingConditions(tc.obj, h.conditions)
 			if !reflect.DeepEqual(badConditions, tc.expected) {
 				t.Errorf("offendingConditions(tc.obj): want %#v, got %#v", tc.expected, badConditions)

--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -14,9 +14,7 @@ import (
 	"go.uber.org/zap"
 	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/record"
 )
 
 const (
@@ -67,12 +65,12 @@ type DrainSchedules struct {
 	logger                       *zap.Logger
 	drainer                      DrainerNodeReplacer
 	preprovisioningConfiguration NodePreprovisioningConfiguration
-	eventRecorder                record.EventRecorder
+	eventRecorder                EventRecorder
 	suppliedConditions           []SuppliedCondition
 	globalLocker                 GlobalBlocker
 }
 
-func NewDrainSchedules(drainer DrainerNodeReplacer, eventRecorder record.EventRecorder, schedulingPeriod, schedulingBackoffDelay time.Duration, labelKeysForGroups []string, suppliedConditions []SuppliedCondition, preprovisioningCfg NodePreprovisioningConfiguration, logger *zap.Logger, locker GlobalBlocker) DrainScheduler {
+func NewDrainSchedules(drainer DrainerNodeReplacer, eventRecorder EventRecorder, schedulingPeriod, schedulingBackoffDelay time.Duration, labelKeysForGroups []string, suppliedConditions []SuppliedCondition, preprovisioningCfg NodePreprovisioningConfiguration, logger *zap.Logger, locker GlobalBlocker) DrainScheduler {
 	sort.Strings(labelKeysForGroups)
 	return &DrainSchedules{
 		labelKeysForGroups:           labelKeysForGroups,
@@ -235,8 +233,7 @@ func (d *DrainSchedules) Schedule(node *v1.Node, failedCount int32) (time.Time, 
 
 	scheduleOptions, err := newScheduleOptions(node)
 	if err != nil {
-		nr := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
-		d.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainConfig, "Failed to get schedule options: %v", err)
+		d.eventRecorder.NodeEventf(node, core.EventTypeWarning, eventReasonDrainConfig, "Failed to get schedule options: %v", err)
 	}
 
 	// compute drain schedule time
@@ -297,7 +294,6 @@ func (s *schedule) isFailed() bool {
 }
 
 func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount int32, scheduleOptions *schedulingOptions) *schedule {
-	nr := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
 	sched := &schedule{
 		when:        when,
 		failedCount: failedCount,
@@ -311,7 +307,7 @@ func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount 
 		if d.globalLocker != nil {
 			if locked, reason := d.globalLocker.IsBlocked(); locked {
 				log.Info("Drain cancelled due to globalLock", zap.String("reason", reason), zap.String("node", node.GetName()))
-				d.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainFailed, "Drain cancelled due to globalLock: %s", reason)
+				d.eventRecorder.NodeEventf(node, core.EventTypeWarning, eventReasonDrainFailed, "Drain cancelled due to globalLock: %s", reason)
 				return
 			}
 		}
@@ -332,11 +328,11 @@ func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount 
 						return false, nil
 					}
 					if !replacementRequestEventDone {
-						d.eventRecorder.Event(nr, core.EventTypeNormal, eventReasonNodePreprovisioning, "Node pre-provisioning before drain: request done")
+						d.eventRecorder.NodeEventf(node, core.EventTypeNormal, eventReasonNodePreprovisioning, "Node pre-provisioning before drain: request done")
 						replacementRequestEventDone = true
 					}
 					if replacementStatus == NodeReplacementStatusDone {
-						d.eventRecorder.Event(nr, core.EventTypeNormal, eventReasonNodePreprovisioningCompleted, "Node pre-provisioning before drain: completed")
+						d.eventRecorder.NodeEventf(node, core.EventTypeNormal, eventReasonNodePreprovisioningCompleted, "Node pre-provisioning before drain: completed")
 						return true, nil
 					}
 					return false, nil
@@ -354,7 +350,7 @@ func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount 
 		}
 
 		// Node drain
-		d.eventRecorder.Event(nr, core.EventTypeNormal, eventReasonDrainStarting, "Draining node")
+		d.eventRecorder.NodeEventf(node, core.EventTypeNormal, eventReasonDrainStarting, "Draining node")
 		if err := d.drainer.Drain(node); err != nil {
 			d.handleDrainFailure(sched, log, err, tags, node)
 			return
@@ -363,9 +359,9 @@ func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount 
 		log.Info("Drained")
 		tags, _ = tag.New(tags, tag.Upsert(TagResult, tagResultSucceeded)) // nolint:gosec
 		StatRecordForEachCondition(tags, node, GetNodeOffendingConditions(node, d.suppliedConditions), MeasureNodesDrained.M(1))
-		d.eventRecorder.Event(nr, core.EventTypeNormal, eventReasonDrainSucceeded, "Drained node")
+		d.eventRecorder.NodeEventf(node, core.EventTypeNormal, eventReasonDrainSucceeded, "Drained node")
 		if err := d.drainer.MarkDrain(node, when, sched.finish, false, failedCount); err != nil {
-			d.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainFailed, "Failed to place drain condition following success: %v", err)
+			d.eventRecorder.NodeEventf(node, core.EventTypeWarning, eventReasonDrainFailed, "Failed to place drain condition following success: %v", err)
 			log.Error(fmt.Sprintf("Failed to place condition following drain success : %v", err))
 		}
 	})
@@ -373,14 +369,13 @@ func (d *DrainSchedules) newSchedule(node *v1.Node, when time.Time, failedCount 
 }
 
 func (d *DrainSchedules) handleDrainFailure(sched *schedule, log *zap.Logger, drainError error, tags context.Context, node *v1.Node) context.Context {
-	nr := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
 	sched.finish = time.Now()
 	sched.setFailed()
 	sched.failedCount++
 	log.Info("Failed to drain", zap.Error(drainError))
 	tags, _ = tag.New(tags, tag.Upsert(TagResult, tagResultFailed), tag.Upsert(TagFailureCause, string(getFailureCause(drainError)))) // nolint:gosec
 	StatRecordForEachCondition(tags, node, GetNodeOffendingConditions(node, d.suppliedConditions), MeasureNodesDrained.M(1))
-	d.eventRecorder.Eventf(nr, core.EventTypeWarning, eventReasonDrainFailed, "Drain failed: %v", drainError)
+	d.eventRecorder.NodeEventf(node, core.EventTypeWarning, eventReasonDrainFailed, "Drain failed: %v", drainError)
 	if err := d.drainer.MarkDrain(node, sched.when, sched.finish, true, sched.failedCount); err != nil {
 		log.Error("Failed to place condition following drain failure")
 	}

--- a/internal/kubernetes/drainSchedule_test.go
+++ b/internal/kubernetes/drainSchedule_test.go
@@ -16,7 +16,7 @@ func TestDrainSchedules_LastSchedule(t *testing.T) {
 	fmt.Println("Now: " + time.Now().Format(time.RFC3339))
 	period := time.Minute
 	node1 := &v1.Node{ObjectMeta: meta.ObjectMeta{Name: "Node1", Annotations: map[string]string{CustomDrainBufferAnnotation: "10m"}}} // Using 10m in initNode ... that should be respected even if the schedule is removed.
-	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
+	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, NewEventRecorder(&record.FakeRecorder{}), period, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
 	whenFirstSched, _ := scheduler.Schedule(node1, 0)
 	scheduler.DeleteSchedule(node1)
 
@@ -55,7 +55,7 @@ func TestDrainSchedules_Schedule(t *testing.T) {
 	fmt.Println("Now: " + time.Now().Format(time.RFC3339))
 	period := time.Minute
 	var failedCount int32 = 0
-	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
+	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, NewEventRecorder(&record.FakeRecorder{}), period, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
 	whenFirstSched, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNode"}}, failedCount)
 	whenFirstSchedSpecificGroup, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNodeGrp", Annotations: map[string]string{DrainGroupAnnotation: "grp1"}}}, failedCount)
 
@@ -145,7 +145,7 @@ func (d *failDrainer) Drain(n *v1.Node) error { return errors.New("myerr") }
 // Test to ensure there are no races when calling HasSchedule while the
 // scheduler is draining a node.
 func TestDrainSchedules_HasSchedule_Polling(t *testing.T) {
-	scheduler := NewDrainSchedules(&failDrainer{}, &record.FakeRecorder{}, 0, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
+	scheduler := NewDrainSchedules(&failDrainer{}, NewEventRecorder(&record.FakeRecorder{}), 0, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
 	node := &v1.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}}
 	var failedCount int32 = 0
 	when, err := scheduler.Schedule(node, failedCount)
@@ -182,7 +182,7 @@ func TestDrainSchedules_DeleteSchedule(t *testing.T) {
 	fmt.Println("Now: " + time.Now().Format(time.RFC3339))
 	period := time.Minute
 	var failedCount int32 = 0
-	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, &record.FakeRecorder{}, period, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
+	scheduler := NewDrainSchedules(&NoopCordonDrainer{}, NewEventRecorder(&record.FakeRecorder{}), period, DefaultSchedulingRetryBackoffDelay, []string{}, []SuppliedCondition{}, NodePreprovisioningConfiguration{}, zap.NewNop(), nil)
 	whenFirstSched, _ := scheduler.Schedule(&v1.Node{ObjectMeta: meta.ObjectMeta{Name: "initNode"}}, failedCount)
 
 	type timeWindow struct {

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -176,7 +176,7 @@ func TestCordon(t *testing.T) {
 			for _, r := range tc.reactions {
 				c.PrependReactor(r.verb, r.resource, r.Fn())
 			}
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, WithCordonLimiter(&fakeLimiter{}))
+			d := NewAPICordonDrainer(c, NewEventRecorder(&record.FakeRecorder{}), WithCordonLimiter(&fakeLimiter{}))
 			if err := d.Cordon(tc.node, tc.mutators...); err != nil {
 				for _, r := range tc.reactions {
 					if errors.Is(err, r.err) {
@@ -263,7 +263,7 @@ func TestUncordon(t *testing.T) {
 			for _, r := range tc.reactions {
 				c.PrependReactor(r.verb, r.resource, r.Fn())
 			}
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{})
+			d := NewAPICordonDrainer(c, NewEventRecorder(&record.FakeRecorder{}))
 			if err := d.Uncordon(tc.node, tc.mutators...); err != nil {
 				for _, r := range tc.reactions {
 					if errors.Is(err, r.err) {
@@ -536,7 +536,7 @@ func TestDrain(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := newFakeClientSet(tc.reactions...)
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{}, tc.options...)
+			d := NewAPICordonDrainer(c, NewEventRecorder(&record.FakeRecorder{}), tc.options...)
 			if err := d.Drain(tc.node); err != nil {
 				for _, r := range tc.reactions {
 					if errors.Is(err, r.err) {
@@ -742,7 +742,7 @@ func TestMarkDrain(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := fake.NewSimpleClientset(tc.node)
-			d := NewAPICordonDrainer(c, &record.FakeRecorder{})
+			d := NewAPICordonDrainer(c, NewEventRecorder(&record.FakeRecorder{}))
 			{
 				n, err := c.CoreV1().Nodes().Get(tc.node.GetName(), meta.GetOptions{})
 				if err != nil {

--- a/internal/kubernetes/event_util.go
+++ b/internal/kubernetes/event_util.go
@@ -1,0 +1,50 @@
+package kubernetes
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	core "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+// This interface centralizes all k8s event interaction for this project.
+// See also https://datadoghq.atlassian.net/wiki/spaces/~960205474/pages/2251949026/Draino+and+Node+Problem+Detector+Event+Inventory
+// which is a datadog specific catalog of all events emit by NLA serving as documentation for users. Changes to events in this project should be reflected in that page.
+type EventRecorder interface {
+	NodeEventf(obj *core.Node, eventtype, reason, messageFmt string, args ...interface{})
+	PodEventf(obj *core.Pod, eventtype, reason, messageFmt string, args ...interface{})
+	PersistentVolumeEventf(obj *core.PersistentVolume, eventtype, reason, messageFmt string, args ...interface{})
+	PersistentVolumeClaimEventf(obj *core.PersistentVolumeClaim, eventtype, reason, messageFmt string, args ...interface{})
+}
+
+type eventRecorder struct {
+	eventRecorder record.EventRecorder
+}
+
+// NewEventRecorder returns a new record.EventRecorder for the given client.
+func NewEventRecorder(k8sEventRecorder record.EventRecorder) EventRecorder {
+	return &eventRecorder{
+		eventRecorder: k8sEventRecorder,
+	}
+}
+
+func (e *eventRecorder) NodeEventf(node *core.Node, eventType, reason, messageFmt string, args ...interface{}) {
+	// Events must be associated with this object reference, rather than the
+	// node itself, in order to appear under `kubectl describe node` due to the
+	// way that command is implemented.
+	// https://github.com/kubernetes/kubernetes/blob/17740a2/pkg/printers/internalversion/describe.go#L2711
+	nodeReference := &core.ObjectReference{Kind: "Node", Name: node.GetName(), UID: types.UID(node.GetName())}
+	e.eventRecorder.Eventf(nodeReference, eventType, reason, messageFmt, args)
+}
+
+func (e *eventRecorder) PodEventf(obj *core.Pod, eventType, reason, messageFmt string, args ...interface{}) {
+	e.eventRecorder.Eventf(obj, eventType, reason, messageFmt, args)
+}
+
+func (e *eventRecorder) PersistentVolumeEventf(obj *core.PersistentVolume, eventType, reason, messageFmt string, args ...interface{}) {
+	e.eventRecorder.Eventf(obj, eventType, reason, messageFmt, args)
+}
+
+func (e *eventRecorder) PersistentVolumeClaimEventf(obj *core.PersistentVolumeClaim, eventType, reason, messageFmt string, args ...interface{}) {
+	e.eventRecorder.Eventf(obj, eventType, reason, messageFmt, args)
+}

--- a/internal/kubernetes/eventhandler_test.go
+++ b/internal/kubernetes/eventhandler_test.go
@@ -380,7 +380,7 @@ func TestDrainingResourceEventHandler(t *testing.T) {
 			store, closeCh := RunStoreForTest(kclient)
 			defer closeCh()
 			cordonDrainer := &mockCordonDrainer{}
-			h := NewDrainingResourceEventHandler(kclient, cordonDrainer, store, &record.FakeRecorder{}, WithDrainBuffer(0*time.Second), WithConditionsFilter(tc.conditions))
+			h := NewDrainingResourceEventHandler(kclient, cordonDrainer, store, NewEventRecorder(&record.FakeRecorder{}), WithDrainBuffer(0*time.Second), WithConditionsFilter(tc.conditions))
 			h.drainScheduler = cordonDrainer
 			h.OnUpdate(nil, tc.obj)
 
@@ -452,7 +452,7 @@ func TestDrainingResourceEventHandler_checkCordonFilters(t *testing.T) {
 
 			h := &DrainingResourceEventHandler{
 				logger:        zap.NewNop(),
-				eventRecorder: &record.FakeRecorder{},
+				eventRecorder: NewEventRecorder(&record.FakeRecorder{}),
 				objectsStore:  store,
 				cordonFilter:  tt.cordonFilter,
 			}

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -35,12 +35,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/record"
 )
 
 // Component is the name of this application.
@@ -72,13 +69,6 @@ func BuildConfigFromFlags(apiserver, kubecfg string) (*rest.Config, error) {
 			&clientcmd.ConfigOverrides{ClusterInfo: api.Cluster{Server: apiserver}}).ClientConfig()
 	}
 	return rest.InClusterConfig()
-}
-
-// NewEventRecorder returns a new record.EventRecorder for the given client.
-func NewEventRecorder(c kubernetes.Interface) record.EventRecorder {
-	b := record.NewBroadcaster()
-	b.StartRecordingToSink(&typedcore.EventSinkImpl{Interface: typedcore.New(c.CoreV1().RESTClient()).Events("")})
-	return b.NewRecorder(scheme.Scheme, core.EventSource{Component: Component})
 }
 
 // RetryWithTimeout this function retries till the function f return a nil error or timeout expire


### PR DESCRIPTION
Most importantly this centralizes the node hack that's required and does
it in a type safe way

After this pr, the event recorder from the k8s `record` package should
never be used directly to create an event