### PR TITLE
add tag for ngName prefix

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -126,7 +126,7 @@ func main() {
 			Measure:     kubernetes.MeasureNodesCordoned,
 			Description: "Number of nodes cordoned.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
+			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
 		nodesUncordoned = &view.View{
 			Name:        "uncordoned_nodes_total",
@@ -140,42 +140,42 @@ func main() {
 			Measure:     kubernetes.MeasureNodesDrained,
 			Description: "Number of nodes drained.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagFailureCause, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
+			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagFailureCause, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
 		nodesDrainScheduled = &view.View{
 			Name:        "drain_scheduled_nodes_total",
 			Measure:     kubernetes.MeasureNodesDrainScheduled,
 			Description: "Number of nodes scheduled for drain.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
+			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
 		limitedCordon = &view.View{
 			Name:        "limited_cordon_total",
 			Measure:     kubernetes.MeasureLimitedCordon,
 			Description: "Number of limited cordon encountered.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagReason, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
+			TagKeys:     []tag.Key{kubernetes.TagReason, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
 		skippedCordon = &view.View{
 			Name:        "skipped_cordon_total",
 			Measure:     kubernetes.MeasureSkippedCordon,
 			Description: "Number of skipped cordon encountered.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagReason, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
+			TagKeys:     []tag.Key{kubernetes.TagReason, kubernetes.TagConditions, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
 		nodesReplacement = &view.View{
 			Name:        "node_replacement_request_total",
 			Measure:     kubernetes.MeasureNodesReplacementRequest,
 			Description: "Number of nodes replacement requested.",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagReason, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
+			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagReason, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
 		nodesPreprovisioningLatency = &view.View{
 			Name:        "node_preprovisioning_latency",
 			Measure:     kubernetes.MeasurePreprovisioningLatency,
 			Description: "Latency to get preprovisioned node",
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagReason, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
+			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagReason, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
 	)
 

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -91,6 +91,7 @@ var (
 	TagConditions, _                      = tag.NewKey("conditions")
 	TagTeam, _                            = tag.NewKey("team")
 	TagNodegroupName, _                   = tag.NewKey("nodegroup_name")
+	TagNodegroupNamePrefix, _             = tag.NewKey("nodegroup_name_prefix")
 	TagNodegroupNamespace, _              = tag.NewKey("nodegroup_namespace")
 	TagResult, _                          = tag.NewKey("result")
 	TagReason, _                          = tag.NewKey("reason")

--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -55,7 +55,7 @@ func (g *metricsObjectsForObserver) reset() error {
 		Measure:     g.MeasureNodesWithNodeOptions,
 		Description: "Number of nodes for each options",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{TagNodegroupName, TagNodegroupNamespace, TagTeam, TagDrainStatus, TagConditions, TagUserOptInViaPodAnnotation, TagUserOptOutViaPodAnnotation, TagUserAllowedConditionsAnnotation, TagDrainRetry, TagDrainRetryFailed, TagDrainRetryCustomMaxAttempt, TagPVCManagement, TagPreprovisioning, TagInScope, TagUserEvictionURL},
+		TagKeys:     []tag.Key{TagNodegroupName, TagNodegroupNamePrefix, TagNodegroupNamespace, TagTeam, TagDrainStatus, TagConditions, TagUserOptInViaPodAnnotation, TagUserOptOutViaPodAnnotation, TagUserAllowedConditionsAnnotation, TagDrainRetry, TagDrainRetryFailed, TagDrainRetryCustomMaxAttempt, TagPVCManagement, TagPreprovisioning, TagInScope, TagUserEvictionURL},
 	}
 
 	view.Register(g.previousMeasureNodesWithNodeOptions)
@@ -208,7 +208,7 @@ func (s *DrainoConfigurationObserverImpl) updateGauges(metrics inScopeMetrics) {
 	for tagsValues, count := range metrics {
 		// This list of tags must be in sync with the list of tags in the function metricsObjectsForObserver::reset()
 		allTags, _ := tag.New(context.Background(),
-			tag.Upsert(TagNodegroupNamespace, tagsValues.NgNamespace), tag.Upsert(TagNodegroupName, tagsValues.NgName),
+			tag.Upsert(TagNodegroupNamespace, tagsValues.NgNamespace), tag.Upsert(TagNodegroupName, tagsValues.NgName), tag.Upsert(TagNodegroupNamePrefix, GetNodeGroupNamePrefix(tagsValues.NgName)),
 			tag.Upsert(TagTeam, tagsValues.Team),
 			tag.Upsert(TagDrainStatus, tagsValues.DrainStatus),
 			tag.Upsert(TagConditions, tagsValues.Condition),

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -220,9 +220,13 @@ func GetNodeTagsValues(node *core.Node) NodeTagsValues {
 	}
 }
 
+func GetNodeGroupNamePrefix(ngName string) string {
+	return strings.Split(ngName, "-")[0]
+}
+
 func nodeTags(ctx context.Context, node *core.Node) (context.Context, error) {
 	values := GetNodeTagsValues(node)
-	return tag.New(ctx, tag.Upsert(TagNodegroupNamespace, values.NgNamespace), tag.Upsert(TagNodegroupName, values.NgName), tag.Upsert(TagTeam, values.Team))
+	return tag.New(ctx, tag.Upsert(TagNodegroupNamespace, values.NgNamespace), tag.Upsert(TagNodegroupName, values.NgName), tag.Upsert(TagNodegroupNamePrefix, GetNodeGroupNamePrefix(values.NgName)), tag.Upsert(TagTeam, values.Team))
 }
 
 func StatRecordForNode(ctx context.Context, node *core.Node, m stats.Measurement) {


### PR DESCRIPTION
We (mainly @matthieujaillais) are today processing offline report to find out what is the good strategy to onboard more applications in NLA. It turned out that one relevant way of grouping the nodes is to use the first part of the NGName.

By experience this creates relevant grouping. Instead of doing that offline and doing data post processing we want to have it done directly on the metric with a new `ng-name-prefix` tag. This way the distribution that we are today computing offline can be created directly into the dsahboard.

Let's note that this grouping is also done a lot by the dashboard users when they filter NG with values like `kafka*`, `logs*`, ...