### PR TITLE
Correctly init klog

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/julienschmidt/httprouter"
@@ -197,11 +196,6 @@ func main() {
 
 	drainoklog.InitializeKlog(*klogVerbosity)
 	drainoklog.RedirectToLogger(log)
-
-	for i := 0; i < 10; i++ {
-		klog.Info("nov", i)
-		klog.V(klog.Level(i)).Info("withv", i)
-	}
 
 	web := &httpRunner{address: *listen, logger: log, h: map[string]http.Handler{
 		"/metrics": p,

--- a/internal/kubernetes/klog/klog.go
+++ b/internal/kubernetes/klog/klog.go
@@ -1,10 +1,20 @@
 package klog
 
 import (
+	"flag"
+	"fmt"
+
 	"go.uber.org/zap"
 	"k8s.io/klog"
-	_ "k8s.io/klog"
 )
+
+// InitializeKlog initializes klog with a verbosity v
+func InitializeKlog(v int32) {
+	fs := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(fs)
+	fs.Set("v", fmt.Sprintf("%d", v))
+	fs.Set("logtostderr", "false")
+}
 
 // RedirectToLogger redirects all klog logs to a zapper logger.
 // This is useful to have a single format for all logs while also getting log messages from libraries that use klog (kubernetes).

--- a/internal/kubernetes/klog/main/main.go
+++ b/internal/kubernetes/klog/main/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	drainoklog "github.com/planetlabs/draino/internal/kubernetes/klog"
+	"go.uber.org/zap"
+	"k8s.io/klog"
+)
+
+// main is a demo of how to use the drainklog utils without using the default os.Args and flag.CommandLine
+func main() {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+	logger = logger.With(zap.String("foo", "bar"))
+
+	drainoklog.InitializeKlog(4)
+	drainoklog.RedirectToLogger(logger)
+
+	for i := 0; i < 10; i++ {
+		klog.Info("nov ", i)
+		klog.V(klog.Level(i)).Info("withv ", i)
+	}
+}


### PR DESCRIPTION
gotchas encountered
* by default, `v` is set to `0` for klog, meaning all klog.V(1) and up
  won't be logged. Defaulted this to `4`
* the default cli flag of `-v` used by klog can't be used since we use
  kingpin that doesn't define its own flags the same way that klog does,
  created a new draino cli flag read by kingpin named `klogVerbosity`
  and forwarded its value to klog
* `klog.InitFlags(...)` sets logtostderr to true, so set this flag to
  false as this isn't what we want
* there is a v1 and a v2 of klog, the same one that is configured is the
  same one that must be used. Currently the version of k8s we depend on
  uses klog v1, when they switch to v2 we will silently lose these logs
  unless we switch to also configuring klog v2