### PR TITLE
add metadata that list condition on the eviction object

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -348,6 +348,7 @@ func main() {
 		kubernetes.WithNodeReplacementLimiter(nodeReplacementLimiter),
 		kubernetes.WithStorageClassesAllowingDeletion(*storageClassesAllowingVolumeDeletion),
 		kubernetes.WithMaxDrainAttemptsBeforeFail(*maxDrainAttemptsBeforeFail),
+		kubernetes.WithSuppliedConditions(*conditions),
 		kubernetes.WithAPICordonDrainerLogger(log),
 	)
 

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -77,7 +77,7 @@ func (r reactor) Fn() clienttesting.ReactionFunc {
 	}
 }
 
-func newFakeClientSet(objects []runtime.Object,rs ...reactor) kubernetes.Interface {
+func newFakeClientSet(objects []runtime.Object, rs ...reactor) kubernetes.Interface {
 	cs := fake.NewSimpleClientset(objects...)
 	for _, r := range rs {
 		cs.AddReactor(r.verb, r.resource, r.Fn())
@@ -296,7 +296,7 @@ func TestDrain(t *testing.T) {
 	}{
 		{
 			name: "EvictOnePod",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			reactions: []reactor{
 				reactor{
 					verb:     "list",
@@ -328,14 +328,16 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name: "NodeSchedulableDontDrain",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: false}},
-			errFn: func(err error) bool { return errors.Is(err, NodeIsNotCordonError{
-				NodeName: nodeName,
-			}) },
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: false}},
+			errFn: func(err error) bool {
+				return errors.Is(err, NodeIsNotCordonError{
+					NodeName: nodeName,
+				})
+			},
 		},
 		{
 			name:    "PodDisappearsBeforeEviction",
-			node:    &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node:    &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			options: []APICordonDrainerOption{MaxGracePeriod(1 * time.Second), EvictionHeadroom(1 * time.Second)},
 			reactions: []reactor{
 				reactor{
@@ -355,7 +357,7 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name: "ErrorEvictingPod",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			reactions: []reactor{
 				reactor{
 					verb:     "list",
@@ -374,7 +376,7 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name:    "PodEvictionNotAllowed",
-			node:    &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node:    &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			options: []APICordonDrainerOption{MaxGracePeriod(1 * time.Second), EvictionHeadroom(1 * time.Second)},
 			reactions: []reactor{
 				reactor{
@@ -395,7 +397,7 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name: "EvictedPodReplacedWithDifferentUID",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			reactions: []reactor{
 				reactor{
 					verb:     "list",
@@ -418,7 +420,7 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name: "ErrorConfirmingPodDeletion",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			reactions: []reactor{
 				reactor{
 					verb:     "list",
@@ -441,7 +443,7 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name: "PodDoesNotPassFilter",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			options: []APICordonDrainerOption{WithPodFilter(func(p core.Pod) (bool, string, error) {
 				if p.GetName() == "lamePod" {
 					// This pod does not pass the filter.
@@ -472,7 +474,7 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name: "PodFilterErrors",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			options: []APICordonDrainerOption{WithPodFilter(func(p core.Pod) (bool, string, error) {
 				if p.GetName() == "explodeyPod" {
 					return false, "explodey", errExploded
@@ -503,12 +505,12 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name:    "SkipDrain",
-			node:    &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node:    &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			options: []APICordonDrainerOption{WithSkipDrain(true), WithAPICordonDrainerLogger(zap.NewNop())},
 		},
 		{
 			name: "ErrorListingPods",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			reactions: []reactor{
 				reactor{
 					verb:     "list",
@@ -519,7 +521,7 @@ func TestDrain(t *testing.T) {
 		},
 		{
 			name: "DoNotEvictTerminatingPodButWaitForDeletion",
-			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName},Spec: core.NodeSpec{Unschedulable: true}},
+			node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: nodeName}, Spec: core.NodeSpec{Unschedulable: true}},
 			reactions: []reactor{{
 				verb:     "list",
 				resource: "pods",
@@ -542,7 +544,7 @@ func TestDrain(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := newFakeClientSet([]runtime.Object{tc.node},tc.reactions...)
+			c := newFakeClientSet([]runtime.Object{tc.node}, tc.reactions...)
 			d := NewAPICordonDrainer(c, NewEventRecorder(&record.FakeRecorder{}), tc.options...)
 			if err := d.Drain(tc.node); err != nil {
 				for _, r := range tc.reactions {


### PR DESCRIPTION
For traceability, we are adding the list of conditions that have triggered the eviction in the annotation of the eviction object that is sent to the eviction++ API