### PR TITLE
bypass cordon filter if the label for opt-in/out is set on the node

### DIFF
--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -314,6 +314,14 @@ func (s *DrainoConfigurationObserverImpl) IsInScope(node *v1.Node) (inScope bool
 	if !s.nodeFilterFunc(node) {
 		return false, "labelSelection", nil
 	}
+
+	if hasLabel, enabled := IsNodeNLAEnableByLabel(node); hasLabel {
+		if !enabled {
+			return false, "Node label explicit opt-out", nil
+		}
+		return true, "", nil
+	}
+
 	var pods []*v1.Pod
 	if pods, err = s.runtimeObjectStore.Pods().ListPodsForNode(node.Name); err != nil {
 		return false, "", err


### PR DESCRIPTION
if the node has a label `node-lifecycle.datadoghq.com/enabled` then the value `true|false` is used to decide to proceed or not with the cordon. In that case we don't look at the workload running in the node to decide to take it in scope or not.