### PR TITLE
check pvc UUID

### DIFF
--- a/internal/kubernetes/nodefilters.go
+++ b/internal/kubernetes/nodefilters.go
@@ -156,6 +156,10 @@ func GetUnscheduledPodsBoundToNodeByPV(node *core.Node, store RuntimeObjectStore
 				logger.Error("Failed to get PVC", zap.String("PVC", pv.Spec.ClaimRef.Namespace+"/"+pv.Spec.ClaimRef.Name), zap.Error(err))
 				return nil, err
 			}
+			if pvc.UID != pv.Spec.ClaimRef.UID {
+				LogForVerboseNode(logger, node, fmt.Sprintf("The PV is different than the one that was bound to that node. UUID on PVC and in the claimRef do not match"))
+				continue
+			}
 			if pvc.DeletionTimestamp != nil {
 				LogForVerboseNode(logger, node, fmt.Sprintf("Ignoring PVC that is terminating %s/%s", pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name))
 				continue


### PR DESCRIPTION
If the PVC is replaced by the controller manager before the check on PVC happens, the system thinks that there is a pod pending and a PVC bound to that node.
In fact only the name match in the claimRef of the PV associated with the node.
If we also check the UUID we will see that the PVC was also deleted.