### PR TITLE
Short lived pod filter

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -353,9 +353,11 @@ func main() {
 		kubernetes.MaxGracePeriod(*maxGracePeriod),
 		kubernetes.EvictionHeadroom(*evictionHeadroom),
 		kubernetes.WithSkipDrain(*skipDrain),
-		kubernetes.WithShortLivedPodFilter(kubernetes.PodOrControllerHasAnyOfTheAnnotations(runtimeObjectStoreImpl, *shortLivedPodAnnotations...)),
-		kubernetes.WithPodFilter(kubernetes.NewPodFiltersIgnoreCompletedPods(
-			kubernetes.NewPodFiltersWithOptInFirst(kubernetes.PodOrControllerHasAnyOfTheAnnotations(runtimeObjectStoreImpl, consolidatedOptInAnnotations...), kubernetes.NewPodFilters(pf...)))),
+		kubernetes.WithPodFilter(
+			kubernetes.NewPodFiltersIgnoreCompletedPods(
+				kubernetes.NewPodFiltersIgnoreShortLivedPods(
+					kubernetes.NewPodFiltersWithOptInFirst(kubernetes.PodOrControllerHasAnyOfTheAnnotations(runtimeObjectStoreImpl, consolidatedOptInAnnotations...), kubernetes.NewPodFilters(pf...)),
+					runtimeObjectStoreImpl, *shortLivedPodAnnotations...))),
 		kubernetes.WithCordonLimiter(cordonLimiter),
 		kubernetes.WithNodeReplacementLimiter(nodeReplacementLimiter),
 		kubernetes.WithStorageClassesAllowingDeletion(*storageClassesAllowingVolumeDeletion),

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -732,7 +732,7 @@ func (d *APICordonDrainer) GetPodsToDrain(ctx context.Context, node string, podS
 					return nil, fmt.Errorf("cannot filter shortLivedPod: %w", err)
 				}
 				if shortLivedPod {
-					continue // we don't want to drain that pod, skip it
+					continue // we don't want to evict that pod, skip it
 				}
 			}
 			include = append(include, p)

--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	ConfigurationLabelKey = "node-lifecycle.datadoghq.com/draino-configuration"
-	OutOfScopeLabelValue  = "out-of-scope"
-	nodeOptionsMetricName = "node_options_nodes_total"
-	nodeOptionsCPUMetricName   = "node_options_cpu_total"
+	ConfigurationLabelKey    = "node-lifecycle.datadoghq.com/draino-configuration"
+	OutOfScopeLabelValue     = "out-of-scope"
+	nodeOptionsMetricName    = "node_options_nodes_total"
+	nodeOptionsCPUMetricName = "node_options_cpu_total"
 )
 
 type DrainoConfigurationObserver interface {


### PR DESCRIPTION
There are some pods, like jobs, or gitlabRunner, or sparkRunnner that should not be evicted.
In such case we want to cordon the node but remove this pod from the eviction list. No eviction we wait for them to complete.

We already have an option for cordonOnly, but for gitlabRunner and sparkRunner we cannot use it because these are special cases that do not have controller (ownerReference), and so the classic feature of CordonOnly can't work because it would be overwritten by the force opt-in filter that we would have to use to bypass the check on the controller.

So here the new annotation, explicitly force-opt-in and at the same time avoid the evict activity.