### PR TITLE
don't retrive on failure for node labeling, just wait for next iteration

### DIFF
--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -19,9 +19,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"strings"
 	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"


### PR DESCRIPTION
When we label the nodes, and there is an error, the system keep trying again and again.... this is not valid if the error is IsNotFound (node was deleted).
For other error, we can wait for next iteration of the observability layer.

Today the queue are saturated by some nodes that always fail due to IsNotFound. As a consequence, other nodes cannot be updated.