### PR TITLE
Remplace "," with "." to be compliant with Label regexp

### DIFF
--- a/internal/kubernetes/observability.go
+++ b/internal/kubernetes/observability.go
@@ -283,7 +283,7 @@ func (s *DrainoConfigurationObserverImpl) addNodeToQueue(node *v1.Node) {
 // value is currently out of date (not equal to first return value)
 func (s *DrainoConfigurationObserverImpl) getLabelUpdate(node *v1.Node) (string, bool, error) {
 	valueOriginal := node.Labels[ConfigurationLabelKey]
-	configsOriginal := strings.Split(valueOriginal, ",")
+	configsOriginal := strings.Split(valueOriginal, ".")
 	var configs []string
 	for _, config := range configsOriginal {
 		if config == "" || config == OutOfScopeLabelValue || config == s.configName {
@@ -304,7 +304,7 @@ func (s *DrainoConfigurationObserverImpl) getLabelUpdate(node *v1.Node) (string,
 		configs = append(configs, OutOfScopeLabelValue)
 	}
 	sort.Strings(configs)
-	valueDesired := strings.Join(configs, ",")
+	valueDesired := strings.Join(configs, ".")
 	return valueDesired, valueDesired != valueOriginal, nil
 }
 

--- a/internal/kubernetes/observability_test.go
+++ b/internal/kubernetes/observability_test.go
@@ -123,7 +123,7 @@ func TestScopeObserverImpl_GetLabelUpdate(t *testing.T) {
 			podFilterFunc:     NewPodFilters(),
 			objects:           []runtime.Object{},
 			node:              getNode("draino2"),
-			expectedValue:     "draino1,draino2",
+			expectedValue:     "draino1.draino2",
 			expectedOutOfDate: true,
 		},
 		{
@@ -142,7 +142,7 @@ func TestScopeObserverImpl_GetLabelUpdate(t *testing.T) {
 			nodeFilterFunc:    func(obj interface{}) bool { return false }, // not in scope
 			podFilterFunc:     NewPodFilters(),
 			objects:           []runtime.Object{},
-			node:              getNode("draino1,other-draino"),
+			node:              getNode("draino1.other-draino"),
 			expectedValue:     "other-draino",
 			expectedOutOfDate: true,
 		},
@@ -152,8 +152,8 @@ func TestScopeObserverImpl_GetLabelUpdate(t *testing.T) {
 			nodeFilterFunc:    func(obj interface{}) bool { return true }, // in scope
 			podFilterFunc:     NewPodFilters(),
 			objects:           []runtime.Object{},
-			node:              getNode("draino2,draino1"),
-			expectedValue:     "draino1,draino2",
+			node:              getNode("draino2.draino1"),
+			expectedValue:     "draino1.draino2",
 			expectedOutOfDate: true,
 		},
 	}


### PR DESCRIPTION
In case the node is eligible for 2 config the label value was using a "," which is not accepted.
```
"error":"Node \"ip-10-49-244-120.ec2.internal\" is invalid: metadata.labels: Invalid value: \"database-with-local-data,standard\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"
```