### PR TITLE
Fix node replacement

### DIFF
--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -361,8 +361,6 @@ func (d *DrainSchedules) newSchedule(ctx context.Context, node *v1.Node, when ti
 						d.eventRecorder.NodeEventf(ctx, node, core.EventTypeNormal, eventReasonNodePreprovisioning, "Node pre-provisioning before drain: request done")
 						replacementStarted = true
 						return false, nil
-					} else {
-						replacementStarted = true
 					}
 					replacementStatus, err := d.drainer.GetReplacementStatus(ctx, node)
 					if err != nil {

--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -23,7 +23,7 @@ const (
 	SetConditionTimeout     = 10 * time.Second
 	SetConditionRetryPeriod = 50 * time.Millisecond
 
-	DefaultPreprovisioningTimeout     = 1 * time.Hour
+	DefaultPreprovisioningTimeout     = 1*time.Hour + 20*time.Minute
 	DefaultPreprovisioningCheckPeriod = 30 * time.Second
 
 	DefaultSchedulingRetryBackoffDelay = 23 * time.Minute
@@ -345,25 +345,36 @@ func (d *DrainSchedules) newSchedule(ctx context.Context, node *v1.Node, when ti
 		// Node preprovisioning
 		if d.hasPreprovisioningAnnotation(node) {
 			log.Info("Start pre-provisioning before drain")
-			replacementRequestEventDone := false // Flag to be sure that we produce the event only once.
 			preprovisionStartTime := time.Now()
 			tags, _ := tag.New(context.Background(), tag.Upsert(TagReason, newNodeRequestReasonPreprovisioning)) // nolint:gosec
+			replacementStarted := false
 			if err := wait.PollImmediate(
 				d.preprovisioningConfiguration.CheckPeriod,
 				d.preprovisioningConfiguration.Timeout,
 				func() (bool, error) {
-					replacementStatus, err := d.drainer.PreprovisionNode(ctx, node)
-					if err != nil {
-						log.Error("Failed to validate node-replacement status", zap.Error(err))
-						return false, nil
-					}
-					if !replacementRequestEventDone {
+					if !replacementStarted {
+						err := d.drainer.PreprovisionNode(ctx, node)
+						if err != nil {
+							log.Error("Failed to start node-replacement", zap.Error(err))
+							return false, nil
+						}
 						d.eventRecorder.NodeEventf(ctx, node, core.EventTypeNormal, eventReasonNodePreprovisioning, "Node pre-provisioning before drain: request done")
-						replacementRequestEventDone = true
+						replacementStarted = true
+						return false, nil
+					} else {
+						replacementStarted = true
+					}
+					replacementStatus, err := d.drainer.GetReplacementStatus(ctx, node)
+					if err != nil {
+						log.Error("Failed to get node replacement status", zap.Error(err))
+						return false, nil
 					}
 					if replacementStatus == NodeReplacementStatusDone {
 						d.eventRecorder.NodeEventf(ctx, node, core.EventTypeNormal, eventReasonNodePreprovisioningCompleted, "Node pre-provisioning before drain: completed")
 						return true, nil
+					}
+					if replacementStatus == NodeReplacementStatusFailed {
+						return false, fmt.Errorf("node pre-provisioning before drain: failed")
 					}
 					return false, nil
 				},

--- a/internal/kubernetes/eventhandler_test.go
+++ b/internal/kubernetes/eventhandler_test.go
@@ -136,20 +136,28 @@ func (d *mockCordonDrainer) DeleteScheduleByName(ctx context.Context, nodeName s
 	})
 }
 
-func (d *mockCordonDrainer) ReplaceNode(ctx context.Context, n *core.Node) (NodeReplacementStatus, error) {
+func (d *mockCordonDrainer) ReplaceNode(ctx context.Context, n *core.Node) (bool, error) {
 	d.calls = append(d.calls, mockCall{
 		name: "ReplaceNode",
 		node: n.Name,
 	})
-	return NodeReplacementStatusNone, nil
+	return false, nil
 }
 
-func (d *mockCordonDrainer) PreprovisionNode(ctx context.Context, n *core.Node) (NodeReplacementStatus, error) {
+func (d *mockCordonDrainer) PreprovisionNode(ctx context.Context, n *core.Node) error {
 	d.calls = append(d.calls, mockCall{
 		name: "PreprovisionNode",
 		node: n.Name,
 	})
-	return NodeReplacementStatusNone, nil
+	return nil
+}
+
+func (d *mockCordonDrainer) GetReplacementStatus(ctx context.Context, n *core.Node) (NodeReplacementStatus, error) {
+	d.calls = append(d.calls, mockCall{
+		name: "GetReplacementStatus",
+		node: n.Name,
+	})
+	return "", nil
 }
 
 func TestDrainingResourceEventHandler(t *testing.T) {
@@ -242,6 +250,7 @@ func TestDrainingResourceEventHandler(t *testing.T) {
 			},
 			expected: []mockCall{
 				{name: "GetPodsToDrain", node: nodeName},
+				{name: "GetReplacementStatus", node: nodeName},
 				{name: "ReplaceNode", node: nodeName},
 			},
 		},


### PR DESCRIPTION
Previously, a "failed" node replacement would never get cleared
Now, we attempt the node replacement by setting this to `requested`
regardless of its previuos state.

Additionally
* we stop waiting when the status is set to failed
* we set the default replacement timeout to slightly longer than the
  node metadata controllers node replacement timeout so the order of
  events is more predictable when the replacement pod is not scheduled

See also https://github.com/DataDog/k8s-node-metadata-controller/pull/35
although it is not a strict dependency on this change.