### PR TITLE
David.benque/queue debugging

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -128,9 +128,9 @@ func main() {
 		// PV/PVC management
 		storageClassesAllowingVolumeDeletion = app.Flag("storage-class-allows-pv-deletion", "Storage class for which persistent volume (and associated claim) deletion is allowed. May be specified multiple times.").PlaceHolder("storageClassName").Strings()
 
-		configName           = app.Flag("config-name", "Name of the draino configuration").Required().String()
-		resetScopeAnnotation = app.Flag("reset-config-annotations", "Reset the scope annotation on the nodes").Bool()
-		scopeAnalysisPeriod  = app.Flag("scope-analysis-period", "Period to run the scope analysis and generate metric").Default((5 * time.Minute).String()).Duration()
+		configName          = app.Flag("config-name", "Name of the draino configuration").Required().String()
+		resetScopeLabel     = app.Flag("reset-config-labels", "Reset the scope label on the nodes").Bool()
+		scopeAnalysisPeriod = app.Flag("scope-analysis-period", "Period to run the scope analysis and generate metric").Default((5 * time.Minute).String()).Duration()
 
 		klogVerbosity = app.Flag("klog-verbosity", "Verbosity to run klog at").Default("4").Int32()
 
@@ -452,7 +452,7 @@ func main() {
 
 	scopeObserver := kubernetes.NewScopeObserver(cs, *configName, kubernetes.ParseConditions(*conditions), runtimeObjectStoreImpl, *scopeAnalysisPeriod, podFilteringFunc, kubernetes.PodOrControllerHasAnyOfTheAnnotations(runtimeObjectStoreImpl, *optInPodAnnotations...), kubernetes.PodOrControllerHasAnyOfTheAnnotations(runtimeObjectStoreImpl, *cordonProtectedPodAnnotations...), nodeLabelFilterFunc, log)
 	go scopeObserver.Run(ctx.Done())
-	if *resetScopeAnnotation == true {
+	if *resetScopeLabel == true {
 		go scopeObserver.Reset()
 	}
 

--- a/internal/kubernetes/observability_test.go
+++ b/internal/kubernetes/observability_test.go
@@ -252,7 +252,7 @@ func TestScopeObserverImpl_updateNodeAnnotationsAndLabels(t *testing.T) {
 				podFilterFunc:      NewPodFilters(),
 				logger:             zap.NewNop(),
 			}
-			err := s.updateNodeLabels(tt.nodeName)
+			err := s.patchNodeLabels(tt.nodeName)
 			if err == nil && tt.wantErr {
 				t.Errorf("Should have returned and error")
 				return


### PR DESCRIPTION
In some cases the observability layer was broken due to a label update that was not happening. Initial observations were:
- nodes were continuously added to the queue (labelling require) and that was expected
- when many nodes are added to the queue periodically, sometimes the dequeuing does not happen anymore

After investigation I figured out that the BucketRateLimiter was scheduling the processing time of the item always further in the future when the dequeuing rate was not able to sustain the pressure. Once the processing delay was increased beyond the add frequency, the items would never be processed again.

The problem is that the bucket rate limiter increase does not take into account that the item is already in the queue, it acts globally and end up increasing the delay at every hit.

I manage to reproduce the problem with that small code sample:
https://gist.github.com/dbenque/56c907adc1a1a1f08d16943cd390d7de

The solution is to keep the exponential backup rate limiter at the queue level, and move the BucketRate limiter on the consumption side to ack as a client side protection for the APIServer. 