### PR TITLE
Remove draino marked check when deciding to uncordon

### DIFF
--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -514,16 +514,6 @@ func (h *DrainingResourceEventHandler) shouldUncordon(ctx context.Context, n *co
 	}
 	logger := TracedLoggerForNode(ctx, n, h.logger)
 
-	drainStatus, err := GetDrainConditionStatus(n)
-	if err != nil {
-		logger.Error(err.Error())
-		return false, err
-	}
-	// Only take the nodes that have been cordon by `draino` (with schedule)
-	if !drainStatus.Marked {
-		return false, nil
-	}
-
 	badConditions := GetNodeOffendingConditions(n, h.conditions)
 	if len(badConditions) == 0 {
 		LogForVerboseNode(logger, n, "No offending condition")


### PR DESCRIPTION
We ran into an issue where a pod was stuck in pending and its PVC was on a cordoned node. If the node was cordoned by draino, it would have been uncordoned. However, since a user manually cordoned the node via `kubectl cordon`, draino did not uncordon the node.

Removing the check will allow draino to uncordon a pod stuck in pending even if a user cordoned the node