### PR TITLE
PVC management is automatically ON if there is no evictionURL defined

### DIFF
--- a/internal/kubernetes/conditions_test.go
+++ b/internal/kubernetes/conditions_test.go
@@ -139,8 +139,8 @@ func TestOffendingConditions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewDrainingResourceEventHandler(fake.NewSimpleClientset(), &NoopCordonDrainer{}, nil, NewEventRecorder(&record.FakeRecorder{}), WithConditionsFilter(tc.conditions))
-			badConditions := GetNodeOffendingConditions(tc.obj, h.conditions)
+			h := NewDrainingResourceEventHandler(fake.NewSimpleClientset(), &NoopCordonDrainer{}, nil, NewEventRecorder(&record.FakeRecorder{}), WithGlobalConfigHandler(GlobalConfig{SuppliedConditions: ParseConditions(tc.conditions)}))
+			badConditions := GetNodeOffendingConditions(tc.obj, h.globalConfig.SuppliedConditions)
 			if !reflect.DeepEqual(badConditions, tc.expected) {
 				t.Errorf("offendingConditions(tc.obj): want %#v, got %#v", tc.expected, badConditions)
 			}

--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -1,0 +1,12 @@
+package kubernetes
+
+type GlobalConfig struct {
+	// ConfigName name of the configuration running this controller, we can have different configuration and multiple draino pods (one per config)
+	ConfigName string
+
+	// PVCManagementEnableIfNoEvictionUrl PVC management is enabled by default if there is no evictionURL defined
+	PVCManagementEnableIfNoEvictionUrl bool
+
+	// SuppliedConditions List of conditions that the controller should react on
+	SuppliedConditions []SuppliedCondition
+}

--- a/internal/kubernetes/eventhandler_test.go
+++ b/internal/kubernetes/eventhandler_test.go
@@ -390,7 +390,7 @@ func TestDrainingResourceEventHandler(t *testing.T) {
 			store, closeCh := RunStoreForTest(kclient)
 			defer closeCh()
 			cordonDrainer := &mockCordonDrainer{}
-			h := NewDrainingResourceEventHandler(kclient, cordonDrainer, store, NewEventRecorder(&record.FakeRecorder{}), WithDrainBuffer(0*time.Second), WithConditionsFilter(tc.conditions))
+			h := NewDrainingResourceEventHandler(kclient, cordonDrainer, store, NewEventRecorder(&record.FakeRecorder{}), WithDrainBuffer(0*time.Second), WithGlobalConfigHandler(GlobalConfig{SuppliedConditions: ParseConditions(tc.conditions)}))
 			h.drainScheduler = cordonDrainer
 			h.OnUpdate(nil, tc.obj)
 

--- a/internal/kubernetes/nodefilters.go
+++ b/internal/kubernetes/nodefilters.go
@@ -138,7 +138,7 @@ func ConvertLabelsToFilterExpr(labelsSlice []string) (*string, error) {
 }
 
 // GetUnscheduledPodsBoundToNodeByPV Check if there is any pod that would be bound to that node due to PV/PVC and that is not yet scheduled
-func GetUnscheduledPodsBoundToNodeByPV(node *core.Node, store RuntimeObjectStore, logger *zap.Logger) ([]*core.Pod, error) {
+func GetUnscheduledPodsBoundToNodeByPV(node *core.Node, store RuntimeObjectStore, pvcManagementDefaultTrueIfNoEvictionURL bool, logger *zap.Logger) ([]*core.Pod, error) {
 	var result []*core.Pod
 	// Is there a local PV on the node
 	pvs := store.PersistentVolumes().GetPVForNode(node)
@@ -174,7 +174,7 @@ func GetUnscheduledPodsBoundToNodeByPV(node *core.Node, store RuntimeObjectStore
 				LogForVerboseNode(logger, node, fmt.Sprintf("Pod for claim "+pv.Spec.ClaimRef.Name+", adding pod "+pod.Name))
 
 				var pendingPodDelay time.Duration
-				if PVCStorageClassCleanupEnabled(pod, store) {
+				if PVCStorageClassCleanupEnabled(pod, store, pvcManagementDefaultTrueIfNoEvictionURL) {
 					// The pod must be long (enough) pending to be sure that we are not looking at the fresh STS while we are performing the PVC cleanup
 					// Adding a 10s delay on top of PVC deletion timeout to be sure that we have time to perform the PVC cleanup
 					pendingPodDelay = 10*time.Second + awaitPVCDeletionTimeout

--- a/internal/kubernetes/nodefilters_test.go
+++ b/internal/kubernetes/nodefilters_test.go
@@ -626,7 +626,7 @@ func TestGetPodsBoundToNodeByPV(t *testing.T) {
 			kclient := fake.NewSimpleClientset(tt.objects...)
 			store, closeCh := RunStoreForTest(kclient)
 			defer closeCh()
-			got, err := GetUnscheduledPodsBoundToNodeByPV(tt.node, store, zap.NewNop())
+			got, err := GetUnscheduledPodsBoundToNodeByPV(tt.node, store, false, zap.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetUnscheduledPodsBoundToNodeByPV() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/kubernetes/observability_test.go
+++ b/internal/kubernetes/observability_test.go
@@ -165,7 +165,7 @@ func TestScopeObserverImpl_GetLabelUpdate(t *testing.T) {
 			s := &DrainoConfigurationObserverImpl{
 				kclient:            kclient,
 				runtimeObjectStore: runtimeObjectStore,
-				configName:         tt.configName,
+				globalConfig:       GlobalConfig{ConfigName: tt.configName},
 				nodeFilterFunc:     tt.nodeFilterFunc,
 				podFilterFunc:      tt.podFilterFunc,
 				logger:             zap.NewNop(),
@@ -246,11 +246,13 @@ func TestScopeObserverImpl_updateNodeAnnotationsAndLabels(t *testing.T) {
 			s := &DrainoConfigurationObserverImpl{
 				kclient:            kclient,
 				runtimeObjectStore: runtimeObjectStore,
-				configName:         tt.configName,
-				conditions:         tt.conditions,
-				nodeFilterFunc:     tt.nodeFilterFunc,
-				podFilterFunc:      NewPodFilters(),
-				logger:             zap.NewNop(),
+				globalConfig: GlobalConfig{
+					ConfigName:         tt.configName,
+					SuppliedConditions: tt.conditions,
+				},
+				nodeFilterFunc: tt.nodeFilterFunc,
+				podFilterFunc:  NewPodFilters(),
+				logger:         zap.NewNop(),
 			}
 			err := s.patchNodeLabels(tt.nodeName)
 			if err == nil && tt.wantErr {

--- a/internal/kubernetes/observability_test.go
+++ b/internal/kubernetes/observability_test.go
@@ -290,3 +290,75 @@ func TestScopeObserverImpl_updateNodeAnnotationsAndLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestPVCStorageClassCleanupEnabled(t *testing.T) {
+
+	tests := []struct {
+		name                       string
+		p                          *v1.Pod
+		defaultTrueIfNoEvictionUrl bool
+		want                       bool
+	}{
+		{
+			name:                       "default false, no annotation",
+			p:                          &v1.Pod{},
+			defaultTrueIfNoEvictionUrl: false,
+			want:                       false,
+		},
+		{
+			name:                       "default true, no annotation",
+			p:                          &v1.Pod{},
+			defaultTrueIfNoEvictionUrl: true,
+			want:                       true,
+		},
+		{
+			name: "default true, explicit opt-out",
+			p: &v1.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{PVCStorageClassCleanupAnnotationKey: PVCStorageClassCleanupAnnotationFalseValue},
+				},
+			},
+			defaultTrueIfNoEvictionUrl: true,
+			want:                       false,
+		},
+		{
+			name: "default false, but explicit opt-in",
+			p: &v1.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{PVCStorageClassCleanupAnnotationKey: PVCStorageClassCleanupAnnotationTrueValue},
+				},
+			},
+			defaultTrueIfNoEvictionUrl: false,
+			want:                       true,
+		},
+		{
+			name: "default true, with evictionURL only",
+			p: &v1.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{EvictionAPIURLAnnotationKey: "url"},
+				},
+			},
+			defaultTrueIfNoEvictionUrl: true,
+			want:                       false,
+		},
+		{
+			name: "default true, with evictionURL and explicit opt-in",
+			p: &v1.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Annotations: map[string]string{PVCStorageClassCleanupAnnotationKey: PVCStorageClassCleanupAnnotationTrueValue, EvictionAPIURLAnnotationKey: "url"},
+				},
+			},
+			defaultTrueIfNoEvictionUrl: true,
+			want:                       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kclient := fake.NewSimpleClientset(tt.p)
+			store, closingFunc := RunStoreForTest(kclient)
+			defer closingFunc()
+
+			assert.Equalf(t, tt.want, PVCStorageClassCleanupEnabled(tt.p, store, tt.defaultTrueIfNoEvictionUrl), "PVCStorageClassCleanupEnabled test=%s", tt.name)
+		})
+	}
+}


### PR DESCRIPTION
We want to activate NLA by default on staging for all applications.
For applications that are having a PVC and a local PV, if nothing is done the PVC is going to be block on the cordon node after the drain.
We don't want to ask every application to opt-in for PVC management. Only application that use eviction++ url can do PVC management on their side (or not, they have to explicitly set the option).

Thanks to this PR, every application that does not use eviction++ URL will have PVC management activated by default. This is piloted by a flag `--pvc-management-by-default` at application level. The default value of the flag is `false`.