### PR TITLE
add missing eviction endpoint failure cause

### DIFF
--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -465,6 +465,14 @@ func getFailureCause(err error) FailureCause {
 	if errors.As(err, &VolumeCleanupError{}) {
 		return VolumeCleanup
 	}
+	var eeErr EvictionEndpointError
+	if errors.As(err, &eeErr) {
+		cause := "eviction_endpoint"
+		if eeErr.StatusCode > 0 {
+			cause += fmt.Sprintf("_%d", eeErr.StatusCode)
+		}
+		return FailureCause(cause)
+	}
 	return ""
 }
 


### PR DESCRIPTION
to be used as metric tag

when eviction endpoint is unreachable (e.g., CNP issue) or returns unexpected status code like 401 unauthorized