### PR TITLE
David.benque/scheduling group runner

### DIFF
--- a/internal/groups/index.go
+++ b/internal/groups/index.go
@@ -1,0 +1,30 @@
+package groups
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	cachek "k8s.io/client-go/tools/cache"
+	cachecr "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	SchedulingGroupIdx = "node:scheduling:group"
+)
+
+// initSchedulingGroupIndexer prepare an index with all the nodes for a given scheduling group
+func initSchedulingGroupIndexer(client client.Client, cache cachecr.Cache, keyGetter GroupKeyGetter) error {
+	informer, err := cache.GetInformer(context.Background(), &v1.Node{})
+	if err != nil {
+		return err
+	}
+	return informer.AddIndexers(map[string]cachek.IndexFunc{
+		SchedulingGroupIdx: func(obj interface{}) ([]string, error) {
+			if n, ok := obj.(*v1.Node); ok {
+				return []string{string(keyGetter.GetGroupKey(n))}, nil
+			}
+			return nil, fmt.Errorf("Expecting node object in SchedulingGroupIdx indexer")
+		},
+	})
+}

--- a/internal/groups/key.go
+++ b/internal/groups/key.go
@@ -1,0 +1,58 @@
+package groups
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+type GroupKey string
+
+type GroupKeyGetter interface {
+	GetGroupKey(node *v1.Node) GroupKey
+}
+
+type GroupKeyFromMetadata struct {
+	labelsKeys                 []string
+	annotationKeys             []string
+	groupOverrideAnnotationKey string
+}
+
+func NewGroupKeyFromNodeMetadata(labelsKeys, annotationKeys []string, groupOverrideAnnotationKey string) GroupKeyGetter {
+	return &GroupKeyFromMetadata{
+		labelsKeys:                 labelsKeys,
+		annotationKeys:             annotationKeys,
+		groupOverrideAnnotationKey: groupOverrideAnnotationKey,
+	}
+}
+
+func getValueOrEmpty(m map[string]string, keys []string) (values []string) {
+	mInitialized := m
+	if mInitialized == nil {
+		mInitialized = map[string]string{}
+	}
+	for _, key := range keys {
+		values = append(values, mInitialized[key])
+	}
+	return
+}
+
+const (
+	GroupKeySeparator = "#"
+)
+
+func (g *GroupKeyFromMetadata) GetGroupKey(node *v1.Node) GroupKey {
+	// slice that contains the values that will compose the groupKey
+	var values []string
+
+	// let's tackle the simple case where the user completely override the groupkey
+	if g.groupOverrideAnnotationKey != "" && node.Annotations != nil {
+		if override, ok := node.Annotations[g.groupOverrideAnnotationKey]; ok && override != "" {
+			// in that case we completely replace the groups, we remove the default groups.
+			// for example, this allows users to define a kubernetes-cluster wide groups if the default is set to namespace
+			values = strings.Split(override, ",")
+		}
+	} else { // let's build the groups values from labels and annotations
+		values = append(getValueOrEmpty(node.Labels, g.labelsKeys), getValueOrEmpty(node.Annotations, g.annotationKeys)...)
+	}
+	return GroupKey(strings.Join(values, GroupKeySeparator))
+}

--- a/internal/groups/key_test.go
+++ b/internal/groups/key_test.go
@@ -1,0 +1,75 @@
+package groups
+
+import (
+	v1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGroupKeyFromMetadata_GetGroupKey(t *testing.T) {
+	tests := []struct {
+		name                       string
+		labelsKeys                 []string
+		annotationKeys             []string
+		groupOverrideAnnotationKey string
+		node                       *v1.Node
+		want                       GroupKey
+	}{
+		{
+			name:       "empty 2 keys labels",
+			labelsKeys: []string{"L1", "L2"},
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Labels:      nil,
+					Annotations: nil,
+				},
+			},
+			want: GroupKey("#"),
+		},
+		{
+			name:           "empty 2 keys labels 1 annotation",
+			labelsKeys:     []string{"L1", "L2"},
+			annotationKeys: []string{"A1"},
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Labels:      nil,
+					Annotations: nil,
+				},
+			},
+			want: GroupKey("##"),
+		},
+		{
+			name:           "values 2 keys labels 2 annotation",
+			labelsKeys:     []string{"L1", "L2"},
+			annotationKeys: []string{"A1", "A2"},
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Labels:      map[string]string{"L0": "l0", "L1": "l1", "L2": "l2", "L3": "l3"},
+					Annotations: map[string]string{"A0": "a0", "A1": "a1", "A2": "a2", "A3": "a3"},
+				},
+			},
+			want: GroupKey("l1#l2#a1#a2"),
+		},
+		{
+			name:                       "override",
+			labelsKeys:                 []string{"L1", "L2"},
+			annotationKeys:             []string{"A1", "A2"},
+			groupOverrideAnnotationKey: "ZZZ",
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Labels:      map[string]string{"L0": "l0", "L1": "l1", "L2": "l2", "L3": "l3"},
+					Annotations: map[string]string{"AAA": "aaa", "A0": "a0", "A1": "a1", "A2": "a2", "A3": "a3", "ZZZ": "zzz,xxx"},
+				},
+			},
+			want: GroupKey("zzz#xxx"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGroupKeyFromNodeMetadata(tt.labelsKeys, tt.annotationKeys, tt.groupOverrideAnnotationKey)
+			if got := g.GetGroupKey(tt.node); got != tt.want {
+				t.Errorf("GetGroupKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/groups/metrics.go
+++ b/internal/groups/metrics.go
@@ -1,0 +1,1 @@
+package groups

--- a/internal/groups/metrics.go
+++ b/internal/groups/metrics.go
@@ -1,1 +1,28 @@
 package groups
+
+import (
+	gmetrics "github.com/DataDog/compute-go/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"sync"
+	"time"
+)
+
+const (
+	publicationPeriod = 20 * time.Second
+)
+
+var (
+	MetricsActiveRunnerTags gmetrics.Tags
+	MetricsActiveRunner     gmetrics.GaugeCleaner
+
+	registerOnceGroupsMetrics sync.Once
+)
+
+// RegisterMetrics registers metrics for the scheduling groups runners
+func RegisterMetrics(registry *prometheus.Registry) {
+	registerOnceGroupsMetrics.Do(func() {
+		MetricsActiveRunnerTags = gmetrics.NewTags() // TODO we can add tags based on the content of RunnerInfo later. Not doing a tag for the group key
+		MetricsActiveRunnerGaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "active_group_runners", Help: "active_group_runners count all the active runners"}, MetricsActiveRunnerTags)
+		MetricsActiveRunner = gmetrics.NewGaugeCleaner(MetricsActiveRunnerGaugeVec, MetricsActiveRunnerTags, 4*publicationPeriod)
+	})
+}

--- a/internal/groups/reconciler_test.go
+++ b/internal/groups/reconciler_test.go
@@ -1,0 +1,117 @@
+package groups
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sync"
+	"testing"
+	"time"
+)
+
+func NewTestRunnerFactory() *TestRunnerFactory {
+	return &TestRunnerFactory{
+		keyGetter: NewGroupKeyFromNodeMetadata([]string{"key"}, nil, ""),
+		runCount:  map[GroupKey]int{},
+		stop:      make(chan struct{}),
+	}
+}
+
+type TestRunnerFactory struct {
+	keyGetter GroupKeyGetter
+	runCount  map[GroupKey]int
+	stop      chan struct{}
+	sync.RWMutex
+}
+
+func (t *TestRunnerFactory) Stop() {
+	close(t.stop)
+}
+
+func (t *TestRunnerFactory) Run(r *RunnerInfo) error {
+	t.Lock()
+	t.runCount[r.key] = t.runCount[r.key] + 1
+	t.Unlock()
+	<-t.stop
+	return nil
+}
+
+func (t *TestRunnerFactory) BuildRunner() Runner {
+	return t
+}
+
+func (t *TestRunnerFactory) GroupKeyGetter() GroupKeyGetter {
+	return t.keyGetter
+}
+
+var _ RunnerFactory = &TestRunnerFactory{}
+
+func TestNewGroupRegistry(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		factory  RunnerFactory
+		nodes    []runtime.Object
+		runCount map[GroupKey]int
+	}{
+		{
+			name:    "test1",
+			factory: NewTestRunnerFactory(),
+			runCount: map[GroupKey]int{
+				"g1": 1,
+				"g2": 1,
+			},
+			nodes: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: meta.ObjectMeta{
+						Name:              "node-g1-1",
+						CreationTimestamp: meta.Time{time.Now().Add(-time.Hour)},
+						Labels:            map[string]string{"key": "g1"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: meta.ObjectMeta{
+						Name:              "node-g1-2",
+						CreationTimestamp: meta.Time{time.Now().Add(-time.Hour)},
+						Labels:            map[string]string{"key": "g1"},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: meta.ObjectMeta{
+						Name:              "node-g2-0",
+						CreationTimestamp: meta.Time{time.Now().Add(-time.Hour)},
+						Labels:            map[string]string{"key": "g2"},
+					},
+				},
+			},
+		},
+	}
+
+	testLogger := logr.New(logr.Discard().GetSink())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(tt.nodes...).Build()
+			gr := NewGroupRegistry(context.Background(), fakeClient, testLogger, tt.factory)
+
+			// inject all the objects
+			for _, o := range tt.nodes {
+				n := o.(*corev1.Node)
+				gr.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: n.Name}})
+			}
+
+			// wait for the runs
+			time.Sleep(time.Second)
+
+			testFactory := tt.factory.(*TestRunnerFactory)
+			assert.Equal(t, tt.runCount, testFactory.runCount)
+			testFactory.Stop()
+		})
+	}
+}

--- a/internal/groups/reconciler_test.go
+++ b/internal/groups/reconciler_test.go
@@ -98,7 +98,7 @@ func TestNewGroupRegistry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(tt.nodes...).Build()
-			gr := NewGroupRegistry(context.Background(), fakeClient, testLogger, tt.factory)
+			gr := NewGroupRegistry(context.Background(), fakeClient, testLogger, nil, tt.factory)
 
 			// inject all the objects
 			for _, o := range tt.nodes {

--- a/internal/groups/runner.go
+++ b/internal/groups/runner.go
@@ -56,6 +56,7 @@ func (g *GroupsRunner) RunForGroup(key GroupKey) {
 func (g *GroupsRunner) runForGroup(key GroupKey) *RunnerInfo {
 	ctx, cancel := context.WithCancel(g.parentContext)
 	r := &RunnerInfo{
+		key:        key,
 		context:    ctx,
 		cancelFunc: cancel,
 	}

--- a/internal/groups/runner.go
+++ b/internal/groups/runner.go
@@ -1,0 +1,76 @@
+package groups
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"sync"
+)
+
+type RunnerInfo struct {
+	context    context.Context
+	cancelFunc context.CancelFunc
+	key        GroupKey
+}
+
+// Runner is in charge of a set of nodes for a given group
+// the runner exit normally if there is no more nodes in the group
+type Runner interface {
+	Run(r *RunnerInfo) error
+}
+
+type RunnerFactory interface {
+	BuildRunner() Runner
+	GroupKeyGetter() GroupKeyGetter
+}
+
+type GroupsRunner struct {
+	sync.RWMutex
+	parentContext context.Context
+	running       map[GroupKey]*RunnerInfo
+	factory       RunnerFactory
+	logger        logr.Logger
+}
+
+func NewGroupsRunner(ctx context.Context, factory RunnerFactory, logger logr.Logger) *GroupsRunner {
+	return &GroupsRunner{
+		parentContext: ctx,
+		running:       map[GroupKey]*RunnerInfo{},
+		factory:       factory,
+		logger:        logger,
+	}
+}
+
+func (g *GroupsRunner) RunForGroup(key GroupKey) {
+	// do nothing if it is already running for that group
+	g.RLock()
+	if _, alReadyRunning := g.running[key]; alReadyRunning {
+		g.RUnlock()
+		return
+	}
+	g.RUnlock()
+	g.Lock()
+	g.running[key] = g.runForGroup(key)
+	g.Unlock()
+}
+
+func (g *GroupsRunner) runForGroup(key GroupKey) *RunnerInfo {
+	ctx, cancel := context.WithCancel(g.parentContext)
+	r := &RunnerInfo{
+		context:    ctx,
+		cancelFunc: cancel,
+	}
+	go func(runInfo *RunnerInfo) {
+		defer runInfo.cancelFunc()
+		g.logger.Info("Scheduling group opened", "groupKey", key)
+		err := g.factory.BuildRunner().Run(runInfo)
+		if err != nil {
+			g.logger.Error(err, "Runner stopped with error", "groupKey", key)
+		}
+
+		g.Lock()
+		delete(g.running, runInfo.key)
+		g.logger.Info("Scheduling group closed", "groupKey", key)
+		g.Unlock()
+	}(r)
+	return r
+}


### PR DESCRIPTION
Building block for scheduling groups:
- indexing: node in a group
- key: interface + key builder based on metadata to have same group than in existing version
- reconciler: ensure that a run is launched for every known node
- groupRunner: run a dedicated go routine (Runner interface) for each group