### PR TITLE
use pdb analyser to evaluate if we should drain or delete a pod

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -210,9 +210,16 @@ func main() {
 			Aggregation: view.Count(),
 			TagKeys:     []tag.Key{kubernetes.TagResult, kubernetes.TagReason, kubernetes.TagNodegroupName, kubernetes.TagNodegroupNamePrefix, kubernetes.TagNodegroupNamespace, kubernetes.TagTeam},
 		}
+		podsRemoved = &view.View{
+			Name:        "pods_removed_total",
+			Measure:     kubernetes.MeasurePodsRemoved,
+			Description: "Number of pods removed from nodes.",
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{kubernetes.TagPodRemovalType},
+		}
 	)
 
-	kingpin.FatalIfError(view.Register(nodesCordoned, nodesUncordoned, nodesDrained, nodesDrainScheduled, limitedCordon, skippedCordon, nodesReplacement, nodesPreprovisioningLatency), "cannot create metrics")
+	kingpin.FatalIfError(view.Register(nodesCordoned, nodesUncordoned, nodesDrained, nodesDrainScheduled, limitedCordon, skippedCordon, nodesReplacement, nodesPreprovisioningLatency, podsRemoved), "cannot create metrics")
 
 	promOptions := prometheus.Options{Namespace: kubernetes.Component, Registry: prom.NewRegistry()}
 	kubernetes.InitWorkqueueMetrics(promOptions.Registry)

--- a/internal/kubernetes/analyser/interface.go
+++ b/internal/kubernetes/analyser/interface.go
@@ -18,5 +18,6 @@ type BlockingPod struct {
 type Interface interface {
 	// BlockingPodsOnNode returns all pods running on the given node, that are taking a disruption budget
 	BlockingPodsOnNode(ctx context.Context, nodeName string) ([]BlockingPod, error)
-	BlockedPDBsByPod(ctx context.Context, podName, ns string) ([]*policyv1.PodDisruptionBudget, error)
+	// IsPodTakingAllBudget will check if the given pod is taking all the disruption budget of the corresponding PDB
+	IsPodTakingAllBudget(ctx context.Context, pod *corev1.Pod) (bool, error)
 }

--- a/internal/kubernetes/analyser/interface.go
+++ b/internal/kubernetes/analyser/interface.go
@@ -18,4 +18,5 @@ type BlockingPod struct {
 type Interface interface {
 	// BlockingPodsOnNode returns all pods running on the given node, that are taking a disruption budget
 	BlockingPodsOnNode(ctx context.Context, nodeName string) ([]BlockingPod, error)
+	BlockedPDBsByPod(ctx context.Context, podName, ns string) ([]*policyv1.PodDisruptionBudget, error)
 }

--- a/internal/kubernetes/analyser/pdb_analyser.go
+++ b/internal/kubernetes/analyser/pdb_analyser.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/planetlabs/draino/internal/kubernetes/index"
 	"github.com/planetlabs/draino/internal/kubernetes/utils"
+	policyv1 "k8s.io/api/policy/v1"
 )
 
 var _ Interface = &PDBAnalyser{}
@@ -48,4 +49,8 @@ func (a *PDBAnalyser) BlockingPodsOnNode(ctx context.Context, nodeName string) (
 	}
 
 	return blockingPods, nil
+}
+
+func (a *PDBAnalyser) BlockedPDBsByPod(ctx context.Context, podName, ns string) ([]*policyv1.PodDisruptionBudget, error) {
+	return a.pdbIndexer.GetPDBsBlockedByPod(ctx, podName, ns)
 }

--- a/internal/kubernetes/analyser/pdb_analyser_test.go
+++ b/internal/kubernetes/analyser/pdb_analyser_test.go
@@ -144,7 +144,7 @@ func TestPDBAnalyser(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			ch := make(chan struct{})
 			defer close(ch)
-			indexer, err := index.NewFakeIndexer(ch, tt.Objects)
+			indexer, err := index.NewFakeIndexer(ch, tt.Objects...)
 			assert.NoError(t, err)
 
 			analyser := NewPDBAnalyser(indexer)

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -89,6 +89,7 @@ var (
 	MeasureSkippedCordon           = stats.Int64("draino/cordon_skipped", "Number of cordon activities that have been skipped due filtering.", stats.UnitDimensionless)
 	MeasureNodesReplacementRequest = stats.Int64("draino/nodes_replacement_request", "Number of nodes replacement requested.", stats.UnitDimensionless)
 	MeasurePreprovisioningLatency  = stats.Float64("draino/nodes_preprovisioning_latency", "Latency to get a node preprovisioned", stats.UnitMilliseconds)
+	MeasurePodsRemoved             = stats.Int64("draino/pods_removed", "Number of pods removed from nodes.", stats.UnitDimensionless)
 
 	TagNodeName, _                        = tag.NewKey("node_name")
 	TagConditions, _                      = tag.NewKey("conditions")
@@ -110,6 +111,7 @@ var (
 	TagUserOptInViaPodAnnotation, _       = tag.NewKey("user_opt_in_via_pod_annotation")
 	TagUserAllowedConditionsAnnotation, _ = tag.NewKey("user_allowed_conditions_annotation")
 	TagUserEvictionURL, _                 = tag.NewKey("eviction_url")
+	TagPodRemovalType, _                  = tag.NewKey("removal_type")
 )
 
 // A DrainingResourceEventHandler cordons and drains any added or updated nodes.

--- a/internal/kubernetes/index/fake.go
+++ b/internal/kubernetes/index/fake.go
@@ -29,7 +29,7 @@ func createCache(inf informers.SharedInformerFactory, scheme *runtime.Scheme) ca
 
 }
 
-func NewFakeIndexer(ch chan struct{}, objects []runtime.Object) (*Indexer, error) {
+func NewFakeIndexer(ch chan struct{}, objects ...runtime.Object) (*Indexer, error) {
 	fakeClient := fake.NewFakeClient(objects...)
 	fakeKubeClient := fakeclient.NewSimpleClientset(objects...)
 
@@ -47,12 +47,12 @@ func NewFakeIndexer(ch chan struct{}, objects []runtime.Object) (*Indexer, error
 	return informer, nil
 }
 
-func NewFakePDBIndexer(ch chan struct{}, objects []runtime.Object) (PDBIndexer, error) {
-	return NewFakeIndexer(ch, objects)
+func NewFakePDBIndexer(ch chan struct{}, objects ...runtime.Object) (PDBIndexer, error) {
+	return NewFakeIndexer(ch, objects...)
 }
 
-func NewFakePodIndexer(ch chan struct{}, objects []runtime.Object) (PodIndexer, error) {
-	return NewFakeIndexer(ch, objects)
+func NewFakePodIndexer(ch chan struct{}, objects ...runtime.Object) (PodIndexer, error) {
+	return NewFakeIndexer(ch, objects...)
 }
 
 type createPodOptions struct {

--- a/internal/kubernetes/index/pdb_test.go
+++ b/internal/kubernetes/index/pdb_test.go
@@ -103,7 +103,7 @@ func Test_PDBIndexer(t *testing.T) {
 			ch := make(chan struct{})
 			defer close(ch)
 
-			informer, err := NewFakePDBIndexer(ch, tt.Objects)
+			informer, err := NewFakePDBIndexer(ch, tt.Objects...)
 			assert.NoError(t, err)
 
 			pdbs, err := informer.GetPDBsBlockedByPod(context.TODO(), tt.TestPodName, tt.TestPodNamespace)

--- a/internal/kubernetes/index/pods_test.go
+++ b/internal/kubernetes/index/pods_test.go
@@ -59,7 +59,7 @@ func Test_PodIndexer(t *testing.T) {
 			ch := make(chan struct{})
 			defer close(ch)
 
-			informer, err := NewFakePodIndexer(ch, tt.Objects)
+			informer, err := NewFakePodIndexer(ch, tt.Objects...)
 			assert.NoError(t, err)
 
 			pods, err := informer.GetPodsByNode(context.TODO(), tt.TestNodeName)


### PR DESCRIPTION
This is a follow-up of https://github.com/DataDog/draino/pull/98

If a pod is not ready, it will take some disruption budget of the corresponding PDB. If we want to evict the not-ready pod, it will complain about missing budget, even though it's the same pod that is taking it.

This PR will check if the given pod is blocking any PDB and if so, it will perform a deletion instead of an eviction.