### PR TITLE
Update Alpine Version to Avoid CVE-2022-37434

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #COPY --from=build /draino /draino
 #ENV PATH="/:${PATH}"
 
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
A Trivy scan shows that zlib is vulnerable to a Critical issue CVE-2022-37434, as version 1.2.12-r0 is in the container. By updating Alpine to 3.15.6 we make sure a newer version of zlib is used that is not susceptible to this vulnerability.