### PR TITLE
cordonProtectAnnotation should also work at controller level

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -290,7 +290,7 @@ func main() {
 		// https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
 		"cluster-autoscaler.kubernetes.io/safe-to-evict=false",
 	}
-	pf = append(pf, kubernetes.UnprotectedPodFilter(append(systemKnownAnnotations, *protectedPodAnnotations...)...))
+	pf = append(pf, kubernetes.UnprotectedPodFilter(runtimeObjectStoreImpl, false, append(systemKnownAnnotations, *protectedPodAnnotations...)...))
 
 	// Cordon Filtering
 	podFilterCordon := []kubernetes.PodFilterFunc{}
@@ -311,7 +311,7 @@ func main() {
 		}
 		podFilterCordon = append(podFilterCordon, kubernetes.NewPodControlledByFilter(apiResourcesCordon))
 	}
-	podFilterCordon = append(podFilterCordon, kubernetes.UnprotectedPodFilter(*cordonProtectedPodAnnotations...))
+	podFilterCordon = append(podFilterCordon, kubernetes.UnprotectedPodFilter(runtimeObjectStoreImpl, true, *cordonProtectedPodAnnotations...))
 
 	// Cordon limiter
 	cordonLimiter := kubernetes.NewCordonLimiter(log)


### PR DESCRIPTION
According to our doc the cordonProtectAnnotation can also be set on the controller of the pod (note that this works only if it is a Statefulset, like for other annotation, limitation that we should fix at some point, not this PR)