### PR TITLE
add drain-buffer checker

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -559,7 +559,7 @@ func controllerRuntimeBootstrap() {
 		os.Exit(1)
 	}
 
-	indexer, err := index.New(mgr.GetClient(), mgr.GetCache())
+	indexer, err := index.New(mgr.GetClient(), mgr.GetCache(), logger)
 	if err != nil {
 		fmt.Printf("error while initializing informer: %v\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dboslee/lru v0.0.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/DataDog/compute-go v1.3.7
 	github.com/DataDog/go-service-authn v1.3.0
 	github.com/antonmedv/expr v1.8.8
+	github.com/go-logr/logr v1.2.2
+	github.com/go-logr/zapr v1.2.3
 	github.com/go-test/deep v1.0.2
 	github.com/googleapis/gnostic v0.5.5
 	github.com/julienschmidt/httprouter v1.3.0
@@ -39,13 +41,10 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dboslee/lru v0.0.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dboslee/lru v0.0.1 h1:PMT+59nkGSkf9Tcb4YMw5B08ilpGgNSmRjEyNK2JVoE=
+github.com/dboslee/lru v0.0.1/go.mod h1:vDIFJHUqr1vdYKAdG9x3r+zFWP0i9uJqQWpB6nSuHxM=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.11.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,6 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dboslee/lru v0.0.1 h1:PMT+59nkGSkf9Tcb4YMw5B08ilpGgNSmRjEyNK2JVoE=
-github.com/dboslee/lru v0.0.1/go.mod h1:vDIFJHUqr1vdYKAdG9x3r+zFWP0i9uJqQWpB6nSuHxM=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.11.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
@@ -948,6 +946,7 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1414,6 +1413,7 @@ gopkg.in/olivere/elastic.v3 v3.0.75/go.mod h1:yDEuSnrM51Pc8dM5ov7U8aI/ToR3PG0llA
 gopkg.in/olivere/elastic.v5 v5.0.84/go.mod h1:LXF6q9XNBxpMqrcgax95C6xyARXWbbCXUrtTxrNrxJI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/internal/kubernetes/analyser/drain_buffer.go
+++ b/internal/kubernetes/analyser/drain_buffer.go
@@ -143,13 +143,13 @@ func (d *drainBufferChecker) runCacheCleanup(ctx context.Context) {
 // if no configuration is found the default value is being used. The result is indexed by podKey
 func (d *drainBufferChecker) getDrainBuffersConfigurations(ctx context.Context, node *v1.Node) map[string]drainBufferInfo {
 	drainBufferNode := drainBufferInfo{
-		sourceKind: "kind/node",
+		sourceKind: "user/node",
 		sourceName: node.Name,
 	}
 	var found bool
 	if drainBufferNode.length, found = d.getNodeDrainBufferConfiguration(ctx, node); !found {
 		drainBufferNode.length = *d.drainBufferConfig.DefaultDrainBuffer
-		drainBufferNode.sourceKind = "default"
+		drainBufferNode.sourceKind = "default/node"
 	}
 
 	buffers := map[string]drainBufferInfo{}
@@ -165,14 +165,14 @@ func (d *drainBufferChecker) getDrainBuffersConfigurations(ctx context.Context, 
 		podDrainBufferConfig, found := d.getPodDrainBufferConfiguration(ctx, p)
 		if found && podDrainBufferConfig > drainBufferPod.length {
 			drainBufferPod.length = podDrainBufferConfig
-			drainBufferPod.sourceKind = "kind/pod"
+			drainBufferPod.sourceKind = "user/pod"
 			drainBufferPod.sourceName = p.Namespace + "/" + p.Name
 
 		} else if ctrl, ok := kubernetes.GetControllerForPod(p, d.store); ok && ctrl != nil {
 			ctrlDrainBufferConfig, found, _ := d.getDrainBufferConfigurationFromAnnotation(ctrl) // Not doing any event on the controller in case of error: we are missing a good method for generic object in the eventRecorder
 			if found && ctrlDrainBufferConfig > drainBufferPod.length {
 				drainBufferPod.length = ctrlDrainBufferConfig
-				drainBufferPod.sourceKind = "kind/controller"
+				drainBufferPod.sourceKind = "user/controller"
 				drainBufferPod.sourceName = p.Namespace + "/" + ctrl.GetName()
 			}
 		}

--- a/internal/kubernetes/analyser/drain_buffer.go
+++ b/internal/kubernetes/analyser/drain_buffer.go
@@ -1,0 +1,328 @@
+package analyser
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	DrainBufferMisconfigured = "DrainBufferMisconfigured"
+
+	DefaultEstimatedRecoveryRecordTTL = 15 * time.Minute
+	DefaultCacheCleanPeriod           = 3 * time.Minute
+	DefaultDrainBufferLength          = 3 * time.Minute
+)
+
+// DrainBufferChecker, can a node be drain and respect drain buffer configuration
+type DrainBufferChecker interface {
+	// DrainBufferAcceptsDrain check if the node can be drained, would we respect all the drain buffer set on the node or on the pods
+	// the time value passed should represent "Now" on a live system. We are passing it to allow simulation (future) and ease unittesting
+	DrainBufferAcceptsDrain(context.Context, *v1.Node, time.Time) bool
+}
+
+// drainBufferChecker, implementation for DrainBufferChecker
+// It retrieves the configuration for drain-buffer on node and pods. It compares this with the pdb transition changes.
+type drainBufferChecker struct {
+	logger            logr.Logger
+	kclient           client.Client
+	eventRecorder     kubernetes.EventRecorder
+	store             kubernetes.RuntimeObjectStore
+	indexer           index.Indexer
+	drainBufferConfig DrainBufferCheckerConfiguration
+
+	// cacheRecoveryTime for a combination {Node+Pods} this cache store the estimated recoveryTime
+	// Note the if a pod is delete from the node the key can't be used anymore, so that cacheclean will remove this key when the TTL expire
+	cacheRecoveryTime cache.ThreadSafeStore
+}
+
+var _ DrainBufferChecker = &drainBufferChecker{}
+
+// drainBufferInfo, the drain buffer configuration can be set on the node, on the pod or the controller of the pod.
+// this structure allow us to carry the value and the source of the configuration
+type drainBufferInfo struct {
+	length     time.Duration
+	sourceKind string
+	sourceName string
+}
+
+// recoveryEstimationDate is used as value in the cache cacheRecoveryTime
+type recoveryEstimationDate struct {
+	estimatedRecovery time.Time
+	ttl               time.Time
+}
+
+// DrainBufferCheckerConfiguration Configuration used in the constructor of DrainBufferChecker
+type DrainBufferCheckerConfiguration struct {
+	// DefaultDrainBuffer, default value to be used if no configuration is given on pods or nodes
+	DefaultDrainBuffer *time.Duration
+	// EstimatedRecoveryRecordTTL, TTL value to be used to remove the record from the cache
+	EstimatedRecoveryRecordTTL *time.Duration
+	// CacheCleanupPeriod, how often we should attempt the cache cleanup
+	CacheCleanupPeriod *time.Duration
+}
+
+func defaultDuration(d **time.Duration, duration time.Duration) {
+	if *d == nil {
+		defaultD := duration
+		*d = &defaultD
+	}
+}
+
+func (c *DrainBufferCheckerConfiguration) applyDefault() {
+	defaultDuration(&c.DefaultDrainBuffer, DefaultDrainBufferLength)
+	defaultDuration(&c.EstimatedRecoveryRecordTTL, DefaultEstimatedRecoveryRecordTTL)
+	defaultDuration(&c.CacheCleanupPeriod, DefaultCacheCleanPeriod)
+}
+
+// NewDrainBufferChecker constructor for the DrainBufferChecker
+func NewDrainBufferChecker(ctx context.Context, logger logr.Logger, kclient client.Client,
+	eventRecorder kubernetes.EventRecorder, store kubernetes.RuntimeObjectStore, indexer index.Indexer,
+	config DrainBufferCheckerConfiguration) DrainBufferChecker {
+	config.applyDefault()
+
+	d := &drainBufferChecker{
+		logger:            logger,
+		kclient:           kclient,
+		eventRecorder:     eventRecorder,
+		store:             store,
+		indexer:           indexer,
+		drainBufferConfig: config,
+		cacheRecoveryTime: cache.NewThreadSafeStore(nil, nil),
+	}
+
+	go d.cacheCleanup(ctx)
+
+	return d
+}
+
+// cacheCleanup, delete all the record with an expired TTL
+func (d *drainBufferChecker) cacheCleanup(ctx context.Context) {
+	logger := d.logger.WithName("drain-buffer-cache")
+	logger.Info("starting cache cleanup")
+	defer logger.Info("stopping cache cleanup")
+	wait.Until(func() {
+		now := time.Now()
+		var toDelete []string
+		keys := d.cacheRecoveryTime.ListKeys()
+		// TODO create a metrics for:
+		// count, nb deleted, time taken to perform the cleanup
+		for _, k := range keys {
+			if obj, ok := d.cacheRecoveryTime.Get(k); ok {
+				record := obj.(recoveryEstimationDate)
+				if record.estimatedRecovery.Before(now) {
+					toDelete = append(toDelete, k)
+					continue
+				}
+				if record.ttl.Before(now) {
+					toDelete = append(toDelete, k)
+				}
+			}
+		}
+		d.logger.Info("cache stats", "count", len(keys), "toBeDeleted", len(toDelete))
+		for _, k := range toDelete {
+			d.cacheRecoveryTime.Delete(k)
+		}
+	},
+		*d.drainBufferConfig.CacheCleanupPeriod,
+		ctx.Done())
+}
+
+// getDrainBuffersConfigurations retrieve the drain-buffers on the node and on the pods of the nodes.
+// if no configuration is found the default value is being used. The result is indexed by podKey
+func (d *drainBufferChecker) getDrainBuffersConfigurations(ctx context.Context, node *v1.Node) map[string]drainBufferInfo {
+	drainBufferNode := drainBufferInfo{
+		sourceKind: "kind/node",
+		sourceName: node.Name,
+	}
+	var found bool
+	if drainBufferNode.length, found = d.getNodeDrainBufferConfiguration(ctx, node); !found {
+		drainBufferNode.length = *d.drainBufferConfig.DefaultDrainBuffer
+		drainBufferNode.sourceKind = "default"
+	}
+
+	buffers := map[string]drainBufferInfo{}
+
+	pods, err := d.indexer.GetPodsByNode(ctx, node.Name)
+	if err != nil {
+		d.logger.Error(err, "Failed to get pods for node", "node", node.Name)
+	}
+
+	for _, p := range pods {
+		drainBufferPod := drainBufferNode // inherit from the node
+		podDrainBufferConfig, found := d.getPodDrainBufferConfiguration(ctx, p)
+		if found && podDrainBufferConfig > drainBufferPod.length {
+			drainBufferPod.length = podDrainBufferConfig
+			drainBufferPod.sourceKind = "kind/pod"
+			drainBufferPod.sourceName = p.Namespace + "/" + p.Name
+
+		} else if ctrl, ok := kubernetes.GetControllerForPod(p, d.store); ok && ctrl != nil {
+			ctrlDrainBufferConfig, found, _ := d.getDrainBufferConfigurationFromAnnotation(ctrl) // Not doing any event on the controller in case of error: we are missing a good method for generic object in the eventRecorder
+			if found && ctrlDrainBufferConfig > drainBufferPod.length {
+				drainBufferPod.length = ctrlDrainBufferConfig
+				drainBufferPod.sourceKind = "kind/controller"
+				drainBufferPod.sourceName = p.Namespace + "/" + ctrl.GetName()
+				buffers[index.GeneratePodIndexKey(p.Name, p.Namespace)] = drainBufferPod
+			}
+		}
+		buffers[index.GeneratePodIndexKey(p.Name, p.Namespace)] = drainBufferPod
+	}
+	return buffers
+}
+
+func (d *drainBufferChecker) getNodeDrainBufferConfiguration(ctx context.Context, node *v1.Node) (time.Duration, bool) {
+	nodeDrainBuffer, found, err := d.getDrainBufferConfigurationFromAnnotation(node)
+	if err != nil {
+		d.eventRecorder.NodeEventf(ctx, node, v1.EventTypeWarning, DrainBufferMisconfigured, "the value for "+kubernetes.CustomDrainBufferAnnotation+" cannot be parsed as a duration: %#v", err)
+	}
+	return nodeDrainBuffer, found
+}
+
+func (d *drainBufferChecker) getPodDrainBufferConfiguration(ctx context.Context, pod *v1.Pod) (time.Duration, bool) {
+	nodeDrainBuffer, found, err := d.getDrainBufferConfigurationFromAnnotation(pod)
+	if err != nil {
+		d.eventRecorder.PodEventf(ctx, pod, v1.EventTypeWarning, DrainBufferMisconfigured, "the value for "+kubernetes.CustomDrainBufferAnnotation+" cannot be parsed as a duration: %#v", err)
+	}
+	return nodeDrainBuffer, found
+}
+
+func (d *drainBufferChecker) getDrainBufferConfigurationFromAnnotation(obj metav1.Object) (time.Duration, bool, error) {
+	annotations := obj.GetAnnotations()
+	if customDrainBuffer, ok := annotations[kubernetes.CustomDrainBufferAnnotation]; ok {
+		durationValue, err := time.ParseDuration(customDrainBuffer)
+		if err != nil {
+			return 0, false, err
+		}
+		return durationValue, true, nil
+	}
+	return 0, false, nil
+}
+
+// DrainBufferAcceptsDrain checks if the node can be drained
+func (d *drainBufferChecker) DrainBufferAcceptsDrain(ctx context.Context, node *v1.Node, now time.Time) bool {
+	// retrieve the drain buffer configuration (from node and pods)
+	drainBuffers := d.getDrainBuffersConfigurations(ctx, node)
+
+	// retrieve all the associated pdb
+	pods, err := d.indexer.GetPodsByNode(ctx, node.Name)
+	if err != nil {
+		d.logger.Error(err, "Failed to get pods for node", "node", node.Name)
+	}
+
+	cacheKey := buildNodePodsCacheKey(node, pods, drainBuffers)
+	if d.cacheRecoveryTime != nil {
+		// check if we have cached result from previous analysis
+		objInCache, found := d.cacheRecoveryTime.Get(cacheKey)
+		if found {
+			recovery := objInCache.(recoveryEstimationDate)
+			if recovery.estimatedRecovery.After(time.Now()) {
+				// TODO add metrics to check how many time the cache was used
+				return false
+			}
+		}
+	}
+
+	pdbsForPods, err := d.indexer.GetPDBsForPods(ctx, pods)
+	if err != nil {
+		d.logger.Error(err, "Failed to retrieve pdbs for the pods of the node", "node", node.Name)
+		// TODO metrics for error
+		return false
+	}
+
+	for podKey, pdbs := range pdbsForPods {
+		drainBuffer := drainBuffers[podKey]
+		disruptionAllowed, stableSince, pdb := getLatestDisruption(d.logger, pdbs)
+		if !disruptionAllowed {
+			pdbName := ""
+			if pdb != nil {
+				pdbName = pdb.Name
+			}
+			d.logger.Info("pdb blocking", "node", node.Name, "pod", podKey, "pdb", pdbName)
+			return false
+		}
+
+		if pdb == nil || stableSince.IsZero() {
+			pdbName := ""
+			if pdb != nil {
+				pdbName = pdb.Name
+			}
+			d.logger.Info("pdb blocking, no condition defined or no pdb", "node", node.Name, "pod", podKey, "pdb", pdbName)
+			return false
+		}
+
+		if now.Sub(stableSince) < drainBuffer.length {
+			pdbName := ""
+			if pdb != nil {
+				pdbName = pdb.Name
+			}
+			d.logger.Info("drain buffer blocking", "node", node.Name, "pod", podKey, "pdb", pdbName, "drain-buffer", drainBuffer)
+
+			if d.cacheRecoveryTime != nil {
+				// add an entry into the cache to avoid recomputing this state before the drain buffer is respected.
+				d.cacheRecoveryTime.Add(cacheKey, recoveryEstimationDate{
+					estimatedRecovery: stableSince.Add(drainBuffer.length),
+					ttl:               now.Add(*d.drainBufferConfig.EstimatedRecoveryRecordTTL),
+				})
+			}
+			return false
+		}
+	}
+	return true
+}
+func buildNodePodsCacheKey(node *v1.Node, pods []*v1.Pod, drainBuffers map[string]drainBufferInfo) string {
+	podsUIDs := make([]string, len(pods))
+	for i, p := range pods {
+		podkey := index.GeneratePodIndexKey(p.Name, p.Namespace)
+		dbuffer := drainBuffers[podkey]
+		// We are using drain buffer because if the configuration change we want to use/introduce a different key.
+		// The cached result may change due to the drainBuffer configuration change
+		podsUIDs[i] = string(p.UID) + dbuffer.length.String()
+	}
+	sort.Strings(podsUIDs) // stable order
+	return string(node.UID) + "#" + strings.Join(podsUIDs, "#")
+}
+
+// getLatestDisruption found for how long the PDB has been stable if the disruption is allowed
+func getLatestDisruption(logger logr.Logger, pdbs []*policyv1.PodDisruptionBudget) (disruptionAllowed bool, stableSince time.Time, disruptedPDB *policyv1.PodDisruptionBudget) {
+	disruptionAllowed = true
+	for _, pdb := range pdbs {
+		conditionFound := false
+		for _, c := range pdb.Status.Conditions {
+			if c.Type == policyv1.DisruptionAllowedCondition {
+				conditionFound = true
+				if c.Status == metav1.ConditionFalse {
+					disruptedPDB = pdb
+					disruptionAllowed = false
+					return
+				}
+				when := c.LastTransitionTime.Time
+				if c.LastTransitionTime.Time.IsZero() {
+					logger.Info("PDB condition without transition timestamp", "namespace", pdb.Namespace, "name", pdb.Name)
+					// logging here because this should not exist, but it is not a blocking problem, we will consider that pdb is stable since its creation
+					when = pdb.CreationTimestamp.Time
+				}
+				if stableSince.Before(when) {
+					disruptedPDB = pdb
+					stableSince = when
+				}
+			}
+		}
+		if !conditionFound {
+			if stableSince.Before(pdb.CreationTimestamp.Time) {
+				disruptedPDB = pdb
+				stableSince = pdb.CreationTimestamp.Time
+			}
+		}
+	}
+	return
+}

--- a/internal/kubernetes/analyser/drain_buffer_test.go
+++ b/internal/kubernetes/analyser/drain_buffer_test.go
@@ -247,7 +247,7 @@ func Test_drainBufferChecker_DrainBufferAcceptsDrain(t *testing.T) {
 							{
 								Type:               policyv1.DisruptionAllowedCondition,
 								Status:             meta.ConditionTrue,
-								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(time.Minute)}, // missing one minute to allow
+								LastTransitionTime: meta.Time{Time: now.Add(-drainBufferOneHour).Add(time.Minute)}, // missing one minute to allow
 							},
 						},
 					},
@@ -286,7 +286,7 @@ func Test_drainBufferChecker_DrainBufferAcceptsDrain(t *testing.T) {
 							{
 								Type:               policyv1.DisruptionAllowedCondition,
 								Status:             meta.ConditionTrue,
-								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(-time.Minute)}, // one extra minute: allowed
+								LastTransitionTime: meta.Time{Time: now.Add(-drainBufferOneHour).Add(-time.Minute)}, // one extra minute: allowed
 							},
 						},
 					},
@@ -303,7 +303,7 @@ func Test_drainBufferChecker_DrainBufferAcceptsDrain(t *testing.T) {
 							{
 								Type:               policyv1.DisruptionAllowedCondition,
 								Status:             meta.ConditionTrue,
-								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(+time.Minute)}, // unrelated pod would block another node
+								LastTransitionTime: meta.Time{Time: now.Add(-drainBufferOneHour).Add(+time.Minute)}, // unrelated pod would block another node
 							},
 						},
 					},
@@ -347,7 +347,7 @@ func Test_drainBufferChecker_DrainBufferAcceptsDrain(t *testing.T) {
 							{
 								Type:               policyv1.DisruptionAllowedCondition,
 								Status:             meta.ConditionTrue,
-								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(-time.Minute)}, // one extra minute: allowed
+								LastTransitionTime: meta.Time{Time: now.Add(-drainBufferOneHour).Add(-time.Minute)}, // one extra minute: allowed
 							},
 						},
 					},
@@ -364,7 +364,7 @@ func Test_drainBufferChecker_DrainBufferAcceptsDrain(t *testing.T) {
 							{
 								Type:               policyv1.DisruptionAllowedCondition,
 								Status:             meta.ConditionTrue,
-								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(+time.Minute)}, // unrelated pod would block another node
+								LastTransitionTime: meta.Time{Time: now.Add(-drainBufferOneHour).Add(+time.Minute)}, // unrelated pod would block another node
 							},
 						},
 					},

--- a/internal/kubernetes/analyser/drain_buffer_test.go
+++ b/internal/kubernetes/analyser/drain_buffer_test.go
@@ -30,7 +30,7 @@ func Test_getLatestDisruption(t *testing.T) {
 				{
 					Type:               policyv1.DisruptionAllowedCondition,
 					Status:             meta.ConditionFalse,
-					LastTransitionTime: meta.Time{date14},
+					LastTransitionTime: meta.Time{Time: date14},
 				},
 			},
 		},
@@ -42,7 +42,7 @@ func Test_getLatestDisruption(t *testing.T) {
 				{
 					Type:               policyv1.DisruptionAllowedCondition,
 					Status:             meta.ConditionTrue,
-					LastTransitionTime: meta.Time{date15},
+					LastTransitionTime: meta.Time{Time: date15},
 				},
 			},
 		},
@@ -54,19 +54,19 @@ func Test_getLatestDisruption(t *testing.T) {
 				{
 					Type:               policyv1.DisruptionAllowedCondition,
 					Status:             meta.ConditionTrue,
-					LastTransitionTime: meta.Time{date16},
+					LastTransitionTime: meta.Time{Time: date16},
 				},
 			},
 		},
 	}
 	pdbNoCondition := &policyv1.PodDisruptionBudget{
-		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoConditions", CreationTimestamp: meta.Time{date16}},
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoConditions", CreationTimestamp: meta.Time{Time: date16}},
 		Status: policyv1.PodDisruptionBudgetStatus{
 			Conditions: []meta.Condition{},
 		},
 	}
 	pdbNoTransitionTime := &policyv1.PodDisruptionBudget{
-		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoTransitionTime", CreationTimestamp: meta.Time{date16}},
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoTransitionTime", CreationTimestamp: meta.Time{Time: date16}},
 		Status: policyv1.PodDisruptionBudgetStatus{
 			Conditions: []meta.Condition{
 				{
@@ -78,7 +78,7 @@ func Test_getLatestDisruption(t *testing.T) {
 		},
 	}
 	pdbNoTransitionTimeButBlocked := &policyv1.PodDisruptionBudget{
-		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoTransitionTime", CreationTimestamp: meta.Time{date16}},
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoTransitionTime", CreationTimestamp: meta.Time{Time: date16}},
 		Status: policyv1.PodDisruptionBudgetStatus{
 			Conditions: []meta.Condition{
 				{
@@ -391,7 +391,7 @@ func Test_drainBufferChecker_DrainBufferAcceptsDrain(t *testing.T) {
 			er := kubernetes.NewEventRecorder(record.NewFakeRecorder(1000))
 			store, closeFunc := kubernetes.RunStoreForTest(context.Background(), fakeKubeClient)
 			defer closeFunc()
-			fakeIndexer, err := index.NewFakeIndexer(ch, tt.objects)
+			fakeIndexer, err := index.NewFakeIndexer(ch, tt.objects, testLogger)
 			if err != nil {
 				t.Fatalf("can't create fakeIndexer: %#v", err)
 			}

--- a/internal/kubernetes/analyser/drain_buffer_test.go
+++ b/internal/kubernetes/analyser/drain_buffer_test.go
@@ -1,0 +1,405 @@
+package analyser
+
+import (
+	"context"
+	"github.com/go-logr/zapr"
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+	"time"
+)
+
+func Test_getLatestDisruption(t *testing.T) {
+	date14 := time.Date(2022, 11, 18, 14, 0, 0, 0, time.UTC)
+	date15 := time.Date(2022, 11, 18, 15, 0, 0, 0, time.UTC)
+	date16 := time.Date(2022, 11, 18, 16, 0, 0, 0, time.UTC)
+
+	pdbBlocked := &policyv1.PodDisruptionBudget{
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbblocked"},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			Conditions: []meta.Condition{
+				{
+					Type:               policyv1.DisruptionAllowedCondition,
+					Status:             meta.ConditionFalse,
+					LastTransitionTime: meta.Time{date14},
+				},
+			},
+		},
+	}
+	pdbOk := &policyv1.PodDisruptionBudget{
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbok"},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			Conditions: []meta.Condition{
+				{
+					Type:               policyv1.DisruptionAllowedCondition,
+					Status:             meta.ConditionTrue,
+					LastTransitionTime: meta.Time{date15},
+				},
+			},
+		},
+	}
+	pdbOk2 := &policyv1.PodDisruptionBudget{
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbok2"},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			Conditions: []meta.Condition{
+				{
+					Type:               policyv1.DisruptionAllowedCondition,
+					Status:             meta.ConditionTrue,
+					LastTransitionTime: meta.Time{date16},
+				},
+			},
+		},
+	}
+	pdbNoCondition := &policyv1.PodDisruptionBudget{
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoConditions", CreationTimestamp: meta.Time{date16}},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			Conditions: []meta.Condition{},
+		},
+	}
+	pdbNoTransitionTime := &policyv1.PodDisruptionBudget{
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoTransitionTime", CreationTimestamp: meta.Time{date16}},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			Conditions: []meta.Condition{
+				{
+					Type:               policyv1.DisruptionAllowedCondition,
+					Status:             meta.ConditionTrue,
+					LastTransitionTime: meta.Time{},
+				},
+			},
+		},
+	}
+	pdbNoTransitionTimeButBlocked := &policyv1.PodDisruptionBudget{
+		ObjectMeta: meta.ObjectMeta{Namespace: "ns", Name: "pdbNoTransitionTime", CreationTimestamp: meta.Time{date16}},
+		Status: policyv1.PodDisruptionBudgetStatus{
+			Conditions: []meta.Condition{
+				{
+					Type:               policyv1.DisruptionAllowedCondition,
+					Status:             meta.ConditionFalse,
+					LastTransitionTime: meta.Time{},
+				},
+			},
+		},
+	}
+	testLogger := zapr.NewLogger(zap.NewNop())
+	tests := []struct {
+		name                  string
+		pdbsForPods           []*policyv1.PodDisruptionBudget
+		wantDisruptionAllowed bool
+		wantStableSince       time.Time
+		wantDisruptedPDB      *policyv1.PodDisruptionBudget
+	}{
+		{
+			name:                  "nil",
+			pdbsForPods:           nil,
+			wantDisruptionAllowed: true,
+			wantStableSince:       time.Time{},
+			wantDisruptedPDB:      nil,
+		},
+		{
+			name:                  "no pdb",
+			pdbsForPods:           []*policyv1.PodDisruptionBudget{},
+			wantDisruptionAllowed: true,
+			wantStableSince:       time.Time{},
+			wantDisruptedPDB:      nil,
+		},
+		{
+			name:                  "2 pdbs with no disruption allowed",
+			pdbsForPods:           []*policyv1.PodDisruptionBudget{pdbBlocked, pdbOk},
+			wantDisruptionAllowed: false,
+			wantStableSince:       time.Time{},
+			wantDisruptedPDB:      pdbBlocked,
+		},
+		{
+			name:                  "2 pdbs with disruption allowed",
+			pdbsForPods:           []*policyv1.PodDisruptionBudget{pdbOk2, pdbOk},
+			wantDisruptionAllowed: true,
+			wantStableSince:       date16,
+			wantDisruptedPDB:      pdbOk2,
+		},
+		{
+			name:                  "no conditions",
+			pdbsForPods:           []*policyv1.PodDisruptionBudget{pdbNoCondition, pdbOk},
+			wantDisruptionAllowed: true,
+			wantStableSince:       date16,
+			wantDisruptedPDB:      pdbNoCondition,
+		},
+		{
+			name:                  "no transitionTime",
+			pdbsForPods:           []*policyv1.PodDisruptionBudget{pdbNoTransitionTime, pdbOk},
+			wantDisruptionAllowed: true,
+			wantStableSince:       date16,
+			wantDisruptedPDB:      pdbNoTransitionTime,
+		},
+		{
+			name:                  "no transitionTime and blocked",
+			pdbsForPods:           []*policyv1.PodDisruptionBudget{pdbNoTransitionTimeButBlocked, pdbOk},
+			wantDisruptionAllowed: false,
+			wantStableSince:       time.Time{},
+			wantDisruptedPDB:      pdbNoTransitionTimeButBlocked,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDisruptionAllowed, gotStableSince, gotDisruptedPDB := getLatestDisruption(testLogger, tt.pdbsForPods)
+			assert.Equalf(t, tt.wantDisruptionAllowed, gotDisruptionAllowed, "disruptionAllowed")
+			assert.Equalf(t, tt.wantStableSince, gotStableSince, "stableSince")
+			assert.Equalf(t, tt.wantDisruptedPDB, gotDisruptedPDB, "pdb")
+		})
+	}
+}
+
+func Test_drainBufferChecker_DrainBufferAcceptsDrain(t *testing.T) {
+	now := time.Date(2022, 11, 19, 18, 00, 00, 00, time.UTC)
+	drainBufferOneHour := time.Hour
+	tests := []struct {
+		name               string
+		objects            []runtime.Object
+		node               *corev1.Node
+		defaultDrainBuffer *time.Duration
+		want               bool
+	}{
+		{
+			name:    "just node, can drain",
+			objects: nil,
+			node: &corev1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "new pdb, using pdb creation timestamp",
+			objects: []runtime.Object{&corev1.Pod{
+				ObjectMeta: meta.ObjectMeta{Name: "pod1", Namespace: "ns",
+					Labels: map[string]string{"app": "test"}},
+				Spec: corev1.PodSpec{NodeName: "node1"},
+			},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: meta.ObjectMeta{Name: "pdb1", Namespace: "ns", CreationTimestamp: meta.Time{Time: now}},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &meta.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			want: false,
+		},
+		{
+			name:               "new pdb, using pdb creation timestamp old enough to accept disruption",
+			defaultDrainBuffer: &drainBufferOneHour,
+			objects: []runtime.Object{&corev1.Pod{
+				ObjectMeta: meta.ObjectMeta{Name: "pod1", Namespace: "ns",
+					Labels: map[string]string{"app": "test"}},
+				Spec: corev1.PodSpec{NodeName: "node1"},
+			},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: meta.ObjectMeta{Name: "pdb1", Namespace: "ns", CreationTimestamp: meta.Time{Time: now.Add(-2 * drainBufferOneHour)}},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &meta.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			want: true,
+		},
+		{
+			name:               "pdb not allowing disruption for long enough",
+			defaultDrainBuffer: &drainBufferOneHour,
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: meta.ObjectMeta{Name: "pod1", Namespace: "ns",
+						Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{NodeName: "node1"},
+				},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: meta.ObjectMeta{Name: "pdb1", Namespace: "ns"},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &meta.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []meta.Condition{
+							{
+								Type:               policyv1.DisruptionAllowedCondition,
+								Status:             meta.ConditionTrue,
+								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(time.Minute)}, // missing one minute to allow
+							},
+						},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			want: false,
+		},
+		{
+			name:               "pdb allowing disruption +1 minute after drainBuffer",
+			defaultDrainBuffer: &drainBufferOneHour,
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: meta.ObjectMeta{Name: "pod1", Namespace: "ns",
+						Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{NodeName: "node1"},
+				},
+				&corev1.Pod{ // unrelated pod (just to create noise)
+					ObjectMeta: meta.ObjectMeta{Name: "podx", Namespace: "ns",
+						Labels: map[string]string{"app": "x"}},
+					Spec: corev1.PodSpec{NodeName: "nodex"},
+				},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: meta.ObjectMeta{Name: "pdb1", Namespace: "ns"},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &meta.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []meta.Condition{
+							{
+								Type:               policyv1.DisruptionAllowedCondition,
+								Status:             meta.ConditionTrue,
+								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(-time.Minute)}, // one extra minute: allowed
+							},
+						},
+					},
+				},
+				&policyv1.PodDisruptionBudget{ // unrelated PDB just to create noise
+					ObjectMeta: meta.ObjectMeta{Name: "pdbx", Namespace: "ns"},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &meta.LabelSelector{
+							MatchLabels: map[string]string{"app": "x"},
+						},
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []meta.Condition{
+							{
+								Type:               policyv1.DisruptionAllowedCondition,
+								Status:             meta.ConditionTrue,
+								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(+time.Minute)}, // unrelated pod would block another node
+							},
+						},
+					},
+				},
+				&corev1.Node{ // unrelated node just to create noise
+					ObjectMeta: meta.ObjectMeta{
+						Name: "nodex",
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			want: true,
+		},
+		{
+			name:               "one of the 2 pods of node1 is blocking",
+			defaultDrainBuffer: &drainBufferOneHour,
+			objects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: meta.ObjectMeta{Name: "pod1", Namespace: "ns",
+						Labels: map[string]string{"app": "test"}},
+					Spec: corev1.PodSpec{NodeName: "node1"},
+				},
+				&corev1.Pod{ // unrelated pod (just to create noise)
+					ObjectMeta: meta.ObjectMeta{Name: "pod2", Namespace: "ns",
+						Labels: map[string]string{"app": "2"}},
+					Spec: corev1.PodSpec{NodeName: "node1"},
+				},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: meta.ObjectMeta{Name: "pdb1", Namespace: "ns"},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &meta.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []meta.Condition{
+							{
+								Type:               policyv1.DisruptionAllowedCondition,
+								Status:             meta.ConditionTrue,
+								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(-time.Minute)}, // one extra minute: allowed
+							},
+						},
+					},
+				},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: meta.ObjectMeta{Name: "pdb2", Namespace: "ns"},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &meta.LabelSelector{
+							MatchLabels: map[string]string{"app": "2"},
+						},
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []meta.Condition{
+							{
+								Type:               policyv1.DisruptionAllowedCondition,
+								Status:             meta.ConditionTrue,
+								LastTransitionTime: meta.Time{now.Add(-drainBufferOneHour).Add(+time.Minute)}, // unrelated pod would block another node
+							},
+						},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			want: false,
+		},
+	}
+
+	testLogger := zapr.NewLogger(zap.NewNop())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := make(chan struct{})
+			defer close(ch)
+			tt.objects = append(tt.objects, tt.node)
+
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(tt.objects...).Build()
+			fakeKubeClient := fakeclient.NewSimpleClientset(tt.objects...)
+			er := kubernetes.NewEventRecorder(record.NewFakeRecorder(1000))
+			store, closeFunc := kubernetes.RunStoreForTest(context.Background(), fakeKubeClient)
+			defer closeFunc()
+			fakeIndexer, err := index.NewFakeIndexer(ch, tt.objects)
+			if err != nil {
+				t.Fatalf("can't create fakeIndexer: %#v", err)
+			}
+			d := NewDrainBufferChecker(context.Background(), testLogger, fakeClient, er, store, *fakeIndexer,
+				DrainBufferCheckerConfiguration{
+					DefaultDrainBuffer: tt.defaultDrainBuffer,
+				})
+			assert.Equalf(t, tt.want, d.DrainBufferAcceptsDrain(context.Background(), tt.node, now), "DrainBufferAcceptsDrain bad result")
+		})
+	}
+}

--- a/internal/kubernetes/analyser/pdb_analyser_test.go
+++ b/internal/kubernetes/analyser/pdb_analyser_test.go
@@ -2,6 +2,8 @@ package analyser
 
 import (
 	"context"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 	"testing"
 
 	"github.com/planetlabs/draino/internal/kubernetes/index"
@@ -140,11 +142,12 @@ func TestPDBAnalyser(t *testing.T) {
 		},
 	}
 
+	testLogger := zapr.NewLogger(zap.NewNop())
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			ch := make(chan struct{})
 			defer close(ch)
-			indexer, err := index.NewFakeIndexer(ch, tt.Objects)
+			indexer, err := index.NewFakeIndexer(ch, tt.Objects, testLogger)
 			assert.NoError(t, err)
 
 			analyser := NewPDBAnalyser(indexer)

--- a/internal/kubernetes/index/fake.go
+++ b/internal/kubernetes/index/fake.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"github.com/go-logr/logr"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,14 +30,14 @@ func createCache(inf informers.SharedInformerFactory, scheme *runtime.Scheme) ca
 
 }
 
-func NewFakeIndexer(ch chan struct{}, objects []runtime.Object) (*Indexer, error) {
+func NewFakeIndexer(ch chan struct{}, objects []runtime.Object, logger logr.Logger) (*Indexer, error) {
 	fakeClient := fake.NewFakeClient(objects...)
 	fakeKubeClient := fakeclient.NewSimpleClientset(objects...)
 
 	inf := informers.NewSharedInformerFactory(fakeKubeClient, 10*time.Second)
 	cache := createCache(inf, fakeClient.Scheme())
 
-	informer, err := New(fakeClient, cache)
+	informer, err := New(fakeClient, cache, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -47,12 +48,12 @@ func NewFakeIndexer(ch chan struct{}, objects []runtime.Object) (*Indexer, error
 	return informer, nil
 }
 
-func NewFakePDBIndexer(ch chan struct{}, objects []runtime.Object) (PDBIndexer, error) {
-	return NewFakeIndexer(ch, objects)
+func NewFakePDBIndexer(ch chan struct{}, objects []runtime.Object, logger logr.Logger) (PDBIndexer, error) {
+	return NewFakeIndexer(ch, objects, logger)
 }
 
-func NewFakePodIndexer(ch chan struct{}, objects []runtime.Object) (PodIndexer, error) {
-	return NewFakeIndexer(ch, objects)
+func NewFakePodIndexer(ch chan struct{}, objects []runtime.Object, logger logr.Logger) (PodIndexer, error) {
+	return NewFakeIndexer(ch, objects, logger)
 }
 
 type createPodOptions struct {

--- a/internal/kubernetes/index/informer.go
+++ b/internal/kubernetes/index/informer.go
@@ -3,14 +3,11 @@ package index
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
 
 	cachek "k8s.io/client-go/tools/cache"
 	cachecr "sigs.k8s.io/controller-runtime/pkg/cache"
 	clientcr "sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	lruPodCapacity = 40000
 )
 
 // Make sure that the Informer is implementing all the required interfaces
@@ -25,11 +22,12 @@ var (
 type Indexer struct {
 	client clientcr.Client
 	cache  cachecr.Cache
+	logger logr.Logger
 }
 
 // New creates and initializes a new Indexer object
-func New(client clientcr.Client, cache cachecr.Cache) (*Indexer, error) {
-	informer := &Indexer{client: client, cache: cache}
+func New(client clientcr.Client, cache cachecr.Cache, logger logr.Logger) (*Indexer, error) {
+	informer := &Indexer{client: client, cache: cache, logger: logger}
 
 	if err := informer.Init(); err != nil {
 		return nil, err

--- a/internal/kubernetes/index/informer.go
+++ b/internal/kubernetes/index/informer.go
@@ -9,6 +9,10 @@ import (
 	clientcr "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	lruPodCapacity = 40000
+)
+
 // Make sure that the Informer is implementing all the required interfaces
 var (
 	_ PDBIndexer = &Indexer{}
@@ -25,7 +29,7 @@ type Indexer struct {
 
 // New creates and initializes a new Indexer object
 func New(client clientcr.Client, cache cachecr.Cache) (*Indexer, error) {
-	informer := &Indexer{client, cache}
+	informer := &Indexer{client: client, cache: cache}
 
 	if err := informer.Init(); err != nil {
 		return nil, err

--- a/internal/kubernetes/index/pdb.go
+++ b/internal/kubernetes/index/pdb.go
@@ -23,13 +23,70 @@ type PDBIndexer interface {
 	// GetPDBsBlockedByPod will return a list of PDBs that are blocked by the given pod.
 	// This means that the disruption budget are used by the Pod.
 	GetPDBsBlockedByPod(ctx context.Context, podName, ns string) ([]*policyv1.PodDisruptionBudget, error)
+
+	// GetPDBsForPods will return a map indexed by podnames
+	// with associated PDBs as value
+	GetPDBsForPods(ctx context.Context, pods []*corev1.Pod) (map[string][]*policyv1.PodDisruptionBudget, error)
 }
 
 func (i *Indexer) GetPDBsBlockedByPod(ctx context.Context, podName, ns string) ([]*policyv1.PodDisruptionBudget, error) {
-	key := generatePodIndexKey(podName, ns)
+	key := GeneratePodIndexKey(podName, ns)
 	return GetFromIndex[policyv1.PodDisruptionBudget](ctx, i, PDBBlockByPodIdx, key)
 }
 
+func (i *Indexer) GetPDBsForPods(ctx context.Context, pods []*corev1.Pod) (map[string][]*policyv1.PodDisruptionBudget, error) {
+	result := map[string][]*policyv1.PodDisruptionBudget{}
+
+	// let's group pods per namespace
+	// to perform analysis per namespace
+	perNamespace := map[string][]*corev1.Pod{}
+	for _, p := range pods {
+		perNs := perNamespace[p.Namespace]
+		perNamespace[p.Namespace] = append(perNs, p)
+	}
+
+	// work for each namespace
+	for ns, podsInNs := range perNamespace {
+		var pdbList policyv1.PodDisruptionBudgetList
+		if err := i.client.List(ctx, &pdbList, &clientcr.ListOptions{Namespace: ns}); err != nil {
+			// TODO log ? missing logger in indexer
+			continue
+		}
+		// local cache for pdb selector (building selector can be expensive)
+		pdbSelectors := map[*policyv1.PodDisruptionBudget]labels.Selector{}
+		getSelector := func(pdb *policyv1.PodDisruptionBudget) (labels.Selector, bool) {
+			if s, ok := pdbSelectors[pdb]; ok {
+				return s, true
+			}
+			selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+			if err != nil {
+				return nil, false
+			}
+			pdbSelectors[pdb] = selector
+			return selector, true
+		}
+
+		for _, pod := range podsInNs {
+			ls := labels.Set(pod.GetLabels())
+			for i := range pdbList.Items {
+				pdb := &pdbList.Items[i]
+				selector, ok := getSelector(pdb)
+				if !ok {
+					// TODO log ? missing logger in indexer
+					continue
+				}
+
+				if !selector.Matches(ls) {
+					continue
+				}
+				podKey := GeneratePodIndexKey(pod.Name, pod.Namespace)
+				otherPDBs := result[podKey]
+				result[podKey] = append(otherPDBs, pdb)
+			}
+		}
+	}
+	return result, nil
+}
 func initPDBIndexer(client clientcr.Client, cache cachecr.Cache) error {
 	informer, err := cache.GetInformer(context.Background(), &policyv1.PodDisruptionBudget{})
 	if err != nil {
@@ -70,13 +127,12 @@ func getBlockingPodsForPDB(client clientcr.Client, pdb *policyv1.PodDisruptionBu
 			continue
 		}
 
-		blockingPods = append(blockingPods, generatePodIndexKey(pod.GetName(), pod.GetNamespace()))
+		blockingPods = append(blockingPods, GeneratePodIndexKey(pod.GetName(), pod.GetNamespace()))
 	}
-
 	return blockingPods, nil
 }
 
-func generatePodIndexKey(podName, ns string) string {
+func GeneratePodIndexKey(podName, ns string) string {
 	// This is needed because PDBs are namespace scoped, so we might have name collisions
-	return fmt.Sprintf("%s/%s", podName, ns)
+	return fmt.Sprintf("%s/%s", podName, ns) // TODO check with Daniel: why in this order ?
 }

--- a/internal/kubernetes/index/pdb_test.go
+++ b/internal/kubernetes/index/pdb_test.go
@@ -2,6 +2,8 @@ package index
 
 import (
 	"context"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,12 +100,13 @@ func Test_PDBIndexer(t *testing.T) {
 		},
 	}
 
+	testLogger := zapr.NewLogger(zap.NewNop())
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			ch := make(chan struct{})
 			defer close(ch)
 
-			informer, err := NewFakePDBIndexer(ch, tt.Objects)
+			informer, err := NewFakePDBIndexer(ch, tt.Objects, testLogger)
 			assert.NoError(t, err)
 
 			pdbs, err := informer.GetPDBsBlockedByPod(context.TODO(), tt.TestPodName, tt.TestPodNamespace)

--- a/internal/kubernetes/index/pods_test.go
+++ b/internal/kubernetes/index/pods_test.go
@@ -2,6 +2,8 @@ package index
 
 import (
 	"context"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,12 +56,13 @@ func Test_PodIndexer(t *testing.T) {
 		},
 	}
 
+	testLogger := zapr.NewLogger(zap.NewNop())
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			ch := make(chan struct{})
 			defer close(ch)
 
-			informer, err := NewFakePodIndexer(ch, tt.Objects)
+			informer, err := NewFakePodIndexer(ch, tt.Objects, testLogger)
 			assert.NoError(t, err)
 
 			pods, err := informer.GetPodsByNode(context.TODO(), tt.TestNodeName)


### PR DESCRIPTION
This PR introduce the drain-buffer checker.
Compare to the legacy implementation where drain-buffer is used from schedule to schedule, this new code allows us to check the stability period of the PDBs associated with the pods on the node.
In other words, the drain-buffer will now allow to define for how long we want the system to be stable before engaging a drain.