### PR TITLE
token-audience for eviction++

### DIFF
--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -812,27 +812,33 @@ func (d *APICordonDrainer) evictWithOperatorAPI(ctx context.Context, url string,
 				return &EvictionEndpointError{}
 			}
 
-			// Uses Emissary to get JWTs.  This is for a production scenario.
-			// Other token getters are available for testing and CLI tools.
-			tg := authnclient.NewEmissaryTokenGetter("runtime-metadata-service")
-
+			// building the base roundTripper
+			var roundTripper http.RoundTripper
 			if urlParsed.Scheme == "https" {
-				tlsConfig := &tls.Config{
-					// We are not trying to verify the server side for the moment
-					// Men in the middle risk is low if not null: CNP helps here.
-					// We can add more verification later if needed
-					InsecureSkipVerify: true,
+				roundTripper = &http.Transport{
+					TLSClientConfig: &tls.Config{
+						// We are not trying to verify the server side for the moment
+						// Men in the middle risk is low if not null: CNP helps here.
+						// We can add more verification later if needed
+						InsecureSkipVerify: true,
+					},
 				}
-				// Creates a round-tripper using the Token Getter.
-				roundTripper := authnclient.NewRoundTripper(&http.Transport{
-					TLSClientConfig: tlsConfig,
-				}, tg)
-				client = &http.Client{Transport: roundTripper, Timeout: 10 * time.Second}
 			} else {
 				// Creates a round-tripper using the Token Getter.
-				roundTripper := authnclient.NewRoundTripper(http.DefaultTransport, tg)
-				client = &http.Client{Transport: roundTripper, Timeout: 10 * time.Second}
+				roundTripper = http.DefaultTransport
 			}
+
+			// If the user specify a parameter "token-audience" on the URL then we will forge a token that is using the value of the parameter as audience in the token
+			// If the user do not specify the audience then that means that he does not want the token (audience is mandatory)
+			tokenAudience := urlParsed.Query().Get("token-audience")
+			if tokenAudience != "" {
+				// Uses Emissary to get JWTs.
+				roundTripper = authnclient.NewRoundTripper(roundTripper, authnclient.NewEmissaryTokenGetter(tokenAudience))
+				// Removing this token parameter so that the server don't get it on the URL. The value is now available for the server inside the bearer token
+				urlParsed.Query().Del("token-audience")
+			}
+
+			client = &http.Client{Transport: roundTripper, Timeout: 10 * time.Second}
 
 			req, err := http.NewRequest("POST", url, GetEvictionJsonPayload(evictionPayload))
 			req = req.WithContext(ctx)

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -824,7 +824,6 @@ func (d *APICordonDrainer) evictWithOperatorAPI(ctx context.Context, url string,
 					},
 				}
 			} else {
-				// Creates a round-tripper using the Token Getter.
 				roundTripper = http.DefaultTransport
 			}
 


### PR DESCRIPTION
When using eviction++ the user should specify the audience if he wants a bearer token to be created. This is done using a query param key=`token-audience`, for example:

```
http://elasticsearch-test-govcloud-1-tools.elasticsearch-test-govcloud-1.local-cluster.local-dc.fabric.dog:8080/api/elasticsearch/evict?token-audience=my-audience
```

For more context about audience:
https://datadoghq.atlassian.net/wiki/spaces/RUNTIME/pages/2649784352/Internal+Service+Authentication#Audience-Configuration

Draino can't decide on the audience. Eviction++ target is defined by the user so we can't know the destination namespace that is behind the URL. This value will be used on the http client side (draino side), and remove from the URL to avoid any side effect on the server parameters validation