### PR TITLE
drain buffer value config

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -499,7 +499,7 @@ func controllerRuntimeBootstrap(options *Options, cfg *controllerruntime.Config,
 	stabilityPeriodChecker := analyser.NewStabilityPeriodChecker(ctx, logger, mgr.GetClient(), nil, store, indexer, analyser.StabilityPeriodCheckerConfiguration{}, filtersDef.drainPodFilter)
 
 	persistor := drainbuffer.NewConfigMapPersistor(cs.CoreV1().ConfigMaps(cfg.InfraParam.Namespace), options.drainBufferConfigMapName, cfg.InfraParam.Namespace)
-	drainBuffer := drainbuffer.NewDrainBuffer(ctx, persistor, clock.RealClock{}, mgr.GetLogger())
+	drainBuffer := drainbuffer.NewDrainBuffer(ctx, persistor, clock.RealClock{}, mgr.GetLogger(), eventRecorder, indexer, store, options.drainBuffer)
 	// The drain buffer can only be initialized when the manager client cache was started.
 	// Adding a custom runnable to the controller manager will make sure, that the initialization will be started as soon as possible.
 	if err := mgr.Add(getInitDrainBufferRunner(drainBuffer, &logger)); err != nil {

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -507,7 +507,7 @@ func controllerRuntimeBootstrap(options *Options, cfg *controllerruntime.Config,
 		return err
 	}
 
-	keyGetter := groups.NewGroupKeyFromNodeMetadata(eventRecorder, indexer, store, strings.Split(options.drainGroupLabelKey, ","), []string{kubernetes.DrainGroupAnnotation}, kubernetes.DrainGroupOverrideAnnotation)
+	keyGetter := groups.NewGroupKeyFromNodeMetadata(mgr.GetLogger(), eventRecorder, indexer, store, strings.Split(options.drainGroupLabelKey, ","), []string{kubernetes.DrainGroupAnnotation}, kubernetes.DrainGroupOverrideAnnotation)
 
 	filterFactory, err := filters.NewFactory(
 		filters.WithLogger(mgr.GetLogger()),

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -507,7 +507,7 @@ func controllerRuntimeBootstrap(options *Options, cfg *controllerruntime.Config,
 		return err
 	}
 
-	keyGetter := groups.NewGroupKeyFromNodeMetadata(mgr.GetLogger(), eventRecorder, indexer, store, strings.Split(options.drainGroupLabelKey, ","), []string{kubernetes.DrainGroupAnnotation}, kubernetes.DrainGroupOverrideAnnotation)
+	keyGetter := groups.NewGroupKeyFromNodeMetadata(mgr.GetClient(), mgr.GetLogger(), eventRecorder, indexer, store, strings.Split(options.drainGroupLabelKey, ","), []string{kubernetes.DrainGroupAnnotation}, kubernetes.DrainGroupOverrideAnnotation)
 
 	filterFactory, err := filters.NewFactory(
 		filters.WithLogger(mgr.GetLogger()),
@@ -584,6 +584,11 @@ func controllerRuntimeBootstrap(options *Options, cfg *controllerruntime.Config,
 	groupRegistry := groups.NewGroupRegistry(ctx, mgr.GetClient(), mgr.GetLogger(), eventRecorder, keyGetter, drainRunnerFactory, drainCandidateRunnerFactory, filtersDef.nodeLabelFilter, store.HasSynced, options.groupRunnerPeriod)
 	if err = groupRegistry.SetupWithManager(mgr); err != nil {
 		logger.Error(err, "failed to setup groupRegistry")
+		return err
+	}
+	groupFromPod := groups.NewGroupFromPod(mgr.GetClient(), mgr.GetLogger(), keyGetter, filtersDef.drainPodFilter, store.HasSynced)
+	if err = groupFromPod.SetupWithManager(mgr); err != nil {
+		logger.Error(err, "failed to setup groupFromPod")
 		return err
 	}
 

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -507,7 +507,7 @@ func controllerRuntimeBootstrap(options *Options, cfg *controllerruntime.Config,
 		return err
 	}
 
-	keyGetter := groups.NewGroupKeyFromNodeMetadata(strings.Split(options.drainGroupLabelKey, ","), []string{kubernetes.DrainGroupAnnotation}, kubernetes.DrainGroupOverrideAnnotation)
+	keyGetter := groups.NewGroupKeyFromNodeMetadata(eventRecorder, indexer, store, strings.Split(options.drainGroupLabelKey, ","), []string{kubernetes.DrainGroupAnnotation}, kubernetes.DrainGroupOverrideAnnotation)
 
 	filterFactory, err := filters.NewFactory(
 		filters.WithLogger(mgr.GetLogger()),

--- a/internal/candidate_runner/info.go
+++ b/internal/candidate_runner/info.go
@@ -1,7 +1,9 @@
 package candidate_runner
 
 import (
+	"context"
 	"encoding/json"
+	"github.com/planetlabs/draino/internal/groups"
 	"time"
 
 	"github.com/planetlabs/draino/internal/scheduler"
@@ -56,6 +58,7 @@ func (d *DataInfoForCleanupActivity) Import(i interface{}) error {
 // CandidateInfo Read only interface that is able to mimic he Candidate Runner behavior
 type CandidateInfo interface {
 	GetNodeIterator(node []*v1.Node) scheduler.ItemProvider[*v1.Node] // TODO consume this in a CLI command to display the tree
+	GetNodes(context.Context, groups.GroupKey) ([]*v1.Node, error)
 }
 
 // CandidateRunnerInfo Read only interface that gives access to runtime information collected in the DataInfo

--- a/internal/candidate_runner/runner_test.go
+++ b/internal/candidate_runner/runner_test.go
@@ -24,13 +24,6 @@ func setClockForTest() clock.Clock {
 	return clockInTest
 }
 
-func Test_candidateRunner_checkNodesRetryWall(t *testing.T) {
-
-}
-
-func Test_candidateRunner_checkNodesTerminating(t *testing.T) {
-}
-
 func Test_candidateRunner_checkAlreadyCandidates(t *testing.T) {
 	setClockForTest()
 	n0 := &corev1.Node{}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,6 +68,15 @@ func (h *CLICommands) buildGroupCmd() *cobra.Command {
 			return h.cmdGroupList()
 		},
 	}
+	groupNodesCmd := &cobra.Command{
+		Use:        "nodes",
+		SuggestFor: []string{"nodes"},
+		Args:       cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return h.cmdGroupNodes()
+		},
+	}
+
 	groupGraphCmd := &cobra.Command{
 		Use:        "graph",
 		SuggestFor: []string{"graph"},
@@ -83,7 +93,7 @@ func (h *CLICommands) buildGroupCmd() *cobra.Command {
 	}
 	groupGraphCmd.AddCommand(groupGraphLastCmd)
 
-	groupCmd.AddCommand(groupListCmd, groupGraphCmd)
+	groupCmd.AddCommand(groupListCmd, groupNodesCmd, groupGraphCmd)
 	return groupCmd
 }
 
@@ -169,6 +179,61 @@ func (h *CLICommands) outputDurationOrTimestamp(t time.Time) string {
 		return duration.ShortHumanDuration(time.Since(t))
 	}
 	return t.Format(time.RFC3339)
+}
+
+func (h *CLICommands) cmdGroupNodes() error {
+	params := url.Values{}
+	params.Add("group-name", h.groupName)
+	b, err := ReadFromURL("http://" + *h.ServerAddr + "/groups/nodes?" + params.Encode())
+	if err != nil {
+		return err
+	}
+
+	if h.outputFormat == formatJSON {
+		fmt.Printf("%s", string(b))
+		return nil
+	}
+
+	var result []diagnostics.NodeDiagnostics
+	if err := json.Unmarshal(b, &result); err != nil {
+		return err
+	}
+
+	table := table.NewTable([]string{
+		"Node", "ns", "ng", "zone", "taint", "filteredOut", "retry", "retry_after", "conditions", "stabilityPeriod", "canDrain",
+	}, func(obj interface{}) []string {
+		item := obj.(diagnostics.NodeDiagnostics)
+
+		retryCount := "-"
+		retryAfter := "-"
+		if item.Retry != nil {
+			retryCount = strconv.Itoa(item.Retry.RetryCount)
+			retryAfter = item.Retry.NextAttemptAfter.Format(time.RFC3339)
+		}
+		var conditions []string
+		for _, c := range item.Conditions {
+			conditions = append(conditions, string(c.Type))
+		}
+		return []string{
+			item.Node,
+			item.Namespace,
+			item.Nodegroup,
+			item.Zone,
+			item.TaintNLA,
+			strconv.FormatBool(!item.Filters.Keep),
+			retryCount,
+			retryAfter,
+			strings.Join(conditions, ","),
+			strconv.FormatBool(item.StabilityPeriodOk),
+			strconv.FormatBool(item.DrainSimulation.CanDrain),
+		}
+	})
+	for _, s := range result {
+		table.Add(s)
+	}
+	h.tableOutputParams.Apply(table)
+	table.Display(os.Stdout)
+	return nil
 }
 
 func (h *CLICommands) cmdGroupList() error {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -253,7 +253,7 @@ func (h *CLICommands) cmdGroupList() error {
 	}
 
 	table := table.NewTable([]string{
-		"Group", "Nodes", "Slot", "Filtered", "Simulation failed", "Warn", "last run aborted", "last candidate run", "candidate duration", "last candidate(s)", "last candidate(s) at", "last candidates sort", "drain duration",
+		"Group", "Nodes", "Slot", "Filtered", "Simulation failed", "Warn", "last run aborted", "last candidate run", "candidate duration", "last candidate(s)", "last candidate(s) at", "last candidates sort", "drain duration", "drainBuffer",
 	},
 		func(obj interface{}) []string {
 			item := obj.(groups.RunnerInfo)
@@ -295,6 +295,7 @@ func (h *CLICommands) cmdGroupList() error {
 				h.outputDurationOrTimestamp(candidateDataInfo.LastCandidatesTime),
 				h.outputDurationOrTimestamp(candidateDataInfo.LastNodeIteratorTime),
 				fmt.Sprintf("%v", drainDataInfo.ProcessingDuration.String()),
+				h.outputDurationOrTimestamp(drainDataInfo.DrainBufferTill),
 			}
 		})
 

--- a/internal/cli/handlers.go
+++ b/internal/cli/handlers.go
@@ -38,6 +38,7 @@ func (c *CLIHandlers) Initialize(logger logr.Logger,
 func (c *CLIHandlers) RegisterRoute(m *mux.Router) {
 	sg := m.PathPrefix("/groups").Subrouter() //Handler(groupRouter)
 	sg.HandleFunc("/list", c.handleGroupsList)
+	sg.HandleFunc("/nodes", c.handleGroupsNodes)
 	sg.HandleFunc("/graph/last", c.handleGroupsGraphLast)
 
 	sn := m.PathPrefix("/nodes").Subrouter() //Handler(groupRouter)
@@ -53,20 +54,58 @@ func (h *CLIHandlers) handleGroupsList(writer http.ResponseWriter, request *http
 		groups = append(groups, v)
 	}
 
-	writer.WriteHeader(http.StatusOK)
 	data, err := json.Marshal(groups)
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	writer.WriteHeader(http.StatusOK)
 	writer.Write(data)
 }
 
-// handleGroupsList list all groups
+// handleGroupsGraphLast display the last sortingTree of the group as a graph
+func (h *CLIHandlers) handleGroupsNodes(writer http.ResponseWriter, request *http.Request) {
+	groupName := request.URL.Query().Get("group-name")
+	h.logger.Info("handleGroupsNodes", "path", request.URL.Path, "groupName", groupName)
+
+	nodes, err := h.candidateInfo.GetNodes(context.Background(), groups.GroupKey(groupName))
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	var result []interface{}
+	for _, n := range nodes {
+		result = append(result, h.diagnostics.GetNodeDiagnostic(context.Background(), n.Name))
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	writer.WriteHeader(http.StatusOK)
+	writer.Write(data)
+}
+
+// handleGroupsGraphLast display the last sortingTree of the group as a graph
 func (h *CLIHandlers) handleGroupsGraphLast(writer http.ResponseWriter, request *http.Request) {
 	groupName := request.URL.Query().Get("group-name")
 	h.logger.Info("handleGroupsGraphLast", "path", request.URL.Path, "groupName", groupName)
 
+	candidateRunnerInfo, ok := h.GetCandidateRunnerInfo(writer, groupName)
+	if !ok {
+		return
+	}
+
+	data, err := json.Marshal(candidateRunnerInfo.GetLastNodeIteratorGraph(true))
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	writer.WriteHeader(http.StatusOK)
+	writer.Write(data)
+}
+
+func (h *CLIHandlers) GetCandidateRunnerInfo(writer http.ResponseWriter, groupName string) (candidate_runner.CandidateRunnerInfo, bool) {
 	var group groups.RunnerInfo
 
 	for k, v := range h.keysGetter.GetRunnerInfo() {
@@ -78,33 +117,26 @@ func (h *CLIHandlers) handleGroupsGraphLast(writer http.ResponseWriter, request 
 	if group.Key == "" {
 		h.logger.Info("handleGroupsGraphLast group not found", "groupName", groupName)
 		writer.WriteHeader(http.StatusNotFound)
-		return
+		return nil, false
 	}
 
 	if group.Data == nil {
 		writer.WriteHeader(http.StatusNoContent)
-		return
+		return nil, false
 	}
 
 	di, ok := group.Data.Get(candidate_runner.CandidateRunnerInfoKey)
 	if !ok {
 		writer.WriteHeader(http.StatusNoContent)
-		return
+		return nil, false
 	}
 
 	candidateRunnerInfo, ok := (di).(candidate_runner.CandidateRunnerInfo)
 	if !ok {
 		writer.WriteHeader(http.StatusInternalServerError)
-		return
+		return nil, false
 	}
-
-	writer.WriteHeader(http.StatusOK)
-	data, err := json.Marshal(candidateRunnerInfo.GetLastNodeIteratorGraph(true))
-	if err != nil {
-		writer.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	writer.Write(data)
+	return candidateRunnerInfo, true
 }
 
 // handleGroupsList list all groups
@@ -114,11 +146,11 @@ func (h *CLIHandlers) handleNodesDiagnostics(writer http.ResponseWriter, request
 
 	result := h.diagnostics.GetNodeDiagnostic(context.Background(), nodeName)
 
-	writer.WriteHeader(http.StatusOK)
 	data, err := json.Marshal(result)
 	if err != nil {
 		writer.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	writer.WriteHeader(http.StatusOK)
 	writer.Write(data)
 }

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -54,6 +54,7 @@ func (diag *Diagnostics) GetNodeDiagnostic(ctx context.Context, nodeName string)
 	if diag.drainBuffer.IsReady() && !nextDrainBufferTime.IsZero() {
 		drainBufferAt = &nextDrainBufferTime
 	}
+	drainBufferConfig, _ := diag.drainBuffer.GetDrainBufferConfigurationDetails(ctx, &node)
 
 	var dsr DrainSimulationResult
 	var errs []error
@@ -77,6 +78,7 @@ func (diag *Diagnostics) GetNodeDiagnostic(ctx context.Context, nodeName string)
 		Filters:           diag.filter.FilterNode(ctx, &node).OnlyFailingChecks(),
 		Retry:             diag.getRetryDiagnostics(&node),
 		DrainBufferAt:     drainBufferAt,
+		DrainBufferConfig: drainBufferConfig,
 		DrainSimulation:   dsr,
 		Conditions:        kubernetes.GetNodeOffendingConditions(&node, diag.suppliedConditions),
 		StabilityPeriodOk: diag.stabilityPeriod.StabilityPeriodAcceptsDrain(ctx, &node, diag.clock.Now()),
@@ -114,17 +116,18 @@ type DrainBufferDiagnostics struct {
 }
 
 type NodeDiagnostics struct {
-	Node              string                         `json:"node"`
-	Nodegroup         string                         `json:"nodegroup,omitempty"`
-	Namespace         string                         `json:"namespace,omitempty"`
-	Zone              string                         `json:"zone,omitempty"`
-	TaintNLA          string                         `json:"taintNLA,omitempty"`
-	Errors            []interface{}                  `json:"errors,omitempty"`
-	GroupKey          string                         `json:"groupKey,omitempty"`
-	DrainBufferAt     *time.Time                     `json:"drainBufferAt,omitempty"`
-	Filters           filters.FilterOutput           `json:"filters,omitempty"`
-	Retry             *RetryDiagnostics              `json:"retry,omitempty"`
-	Conditions        []kubernetes.SuppliedCondition `json:"conditions,omitempty"`
-	DrainSimulation   DrainSimulationResult          `json:"drainSimulation,omitempty"`
-	StabilityPeriodOk bool                           `json:"stabilityPeriodOk"`
+	Node              string                                           `json:"node"`
+	Nodegroup         string                                           `json:"nodegroup,omitempty"`
+	Namespace         string                                           `json:"namespace,omitempty"`
+	Zone              string                                           `json:"zone,omitempty"`
+	TaintNLA          string                                           `json:"taintNLA,omitempty"`
+	Errors            []interface{}                                    `json:"errors,omitempty"`
+	GroupKey          string                                           `json:"groupKey,omitempty"`
+	DrainBufferAt     *time.Time                                       `json:"drainBufferAt,omitempty"`
+	DrainBufferConfig kubernetes.AnnotationSearchResult[time.Duration] `json:"drainBufferConfig,omitempty"`
+	Filters           filters.FilterOutput                             `json:"filters,omitempty"`
+	Retry             *RetryDiagnostics                                `json:"retry,omitempty"`
+	Conditions        []kubernetes.SuppliedCondition                   `json:"conditions,omitempty"`
+	DrainSimulation   DrainSimulationResult                            `json:"drainSimulation,omitempty"`
+	StabilityPeriodOk bool                                             `json:"stabilityPeriodOk"`
 }

--- a/internal/drain_buffer/drain_buffer.go
+++ b/internal/drain_buffer/drain_buffer.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/DataDog/compute-go/logs"
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	v1 "k8s.io/api/core/v1"
 	"sync"
 	"time"
 
@@ -26,7 +30,13 @@ type DrainBuffer interface {
 	Initialize(context.Context) error
 	// IsReady returns true if the initialization was finished successfully
 	IsReady() bool
+	// GetDrainBufferConfiguration retrieve the drain buffer configuration with a node (and associated pods)
+	GetDrainBufferConfiguration(ctx context.Context, node *v1.Node) (time.Duration, error)
+	// GetDrainBufferConfigurationDetails retrieve the drain buffer configuration with a node (and associated pods)
+	GetDrainBufferConfigurationDetails(ctx context.Context, node *v1.Node) (kubernetes.AnnotationSearchResult[time.Duration], error)
 }
+
+var _ DrainBuffer = &drainBufferImpl{}
 
 // drainCache is cache used internally by the drain buffer
 type drainCache map[groups.GroupKey]drainCacheEntry
@@ -43,21 +53,72 @@ type drainBufferImpl struct {
 	isInitialized bool
 	isDirty       bool
 
-	clock     clock.Clock
-	persistor Persistor
-	cache     drainCache
-	logger    *logr.Logger
+	podIndexer    index.PodIndexer
+	store         kubernetes.RuntimeObjectStore
+	eventRecorder kubernetes.EventRecorder
+	clock         clock.Clock
+	persistor     Persistor
+	cache         drainCache
+	logger        logr.Logger
+
+	defaultDrainBuffer time.Duration
+}
+
+const (
+	eventDrainBufferBadConfiguration = "DrainBufferBadConfiguration"
+)
+
+// GetDrainBufferConfigurationDetails retrieve all the drain configuration details
+func (buffer *drainBufferImpl) GetDrainBufferConfigurationDetails(ctx context.Context, node *v1.Node) (kubernetes.AnnotationSearchResult[time.Duration], error) {
+	return kubernetes.GetAnnotationFromNodeAndThenPodOrController(ctx, buffer.podIndexer, buffer.store, time.ParseDuration, kubernetes.CustomDrainBufferAnnotation, node, false, false)
+}
+
+// GetDrainBufferConfiguration does a best effort to find a valid configuration and always return a value. The error can be non nil if something went wrong during the processing, still the value can be used. Worst case you get the default value.
+func (buffer *drainBufferImpl) GetDrainBufferConfiguration(ctx context.Context, node *v1.Node) (time.Duration, error) {
+	searchResult, err := buffer.GetDrainBufferConfigurationDetails(ctx, node)
+	if err != nil || !searchResult.Found {
+		return buffer.defaultDrainBuffer, err
+	}
+
+	cleanResult, ok := searchResult.PruneErrors(
+		func(node *v1.Node, err error) {
+			buffer.eventRecorder.NodeEventf(ctx, node, v1.EventTypeWarning, eventDrainBufferBadConfiguration, "failed to parse drainBuffer: "+err.Error()) // The parsing error is given to the user
+		},
+		func(pod *v1.Pod, err error) {
+			buffer.eventRecorder.PodEventf(ctx, pod, v1.EventTypeWarning, eventDrainBufferBadConfiguration, "failed to parse drainBuffer: "+err.Error()) // The parsing error is given to the user
+		},
+	)
+	if !ok {
+		buffer.logger.V(logs.ZapDebug).Info("Fail to parse some of the drainBuffer", "node", node.Name)
+	}
+
+	durations := cleanResult.AsSlice()
+	if len(durations) == 0 {
+		return buffer.defaultDrainBuffer, err
+	}
+
+	var max time.Duration
+	for _, d := range durations {
+		if d > max {
+			max = d
+		}
+	}
+	return max, nil
 }
 
 // NewDrainBuffer returns a new instance of a drain buffer
-func NewDrainBuffer(ctx context.Context, persistor Persistor, clock clock.Clock, logger logr.Logger) DrainBuffer {
+func NewDrainBuffer(ctx context.Context, persistor Persistor, clock clock.Clock, logger logr.Logger, eventRecorder kubernetes.EventRecorder, podIndexer index.PodIndexer, store kubernetes.RuntimeObjectStore, defaultDrainBuffer time.Duration) DrainBuffer {
 	drainBuffer := &drainBufferImpl{
-		isInitialized: false,
-		isDirty:       false,
-		clock:         clock,
-		persistor:     persistor,
-		cache:         drainCache{},
-		logger:        &logger,
+		defaultDrainBuffer: defaultDrainBuffer,
+		isInitialized:      false,
+		isDirty:            false,
+		clock:              clock,
+		persistor:          persistor,
+		cache:              drainCache{},
+		logger:             logger.WithName("drainBuffer"),
+		eventRecorder:      eventRecorder,
+		podIndexer:         podIndexer,
+		store:              store,
 	}
 
 	go drainBuffer.persistenceLoop(ctx)

--- a/internal/drain_buffer/drain_buffer_test.go
+++ b/internal/drain_buffer/drain_buffer_test.go
@@ -1,6 +1,8 @@
 package drainbuffer
 
 import (
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"k8s.io/client-go/tools/record"
 	"testing"
 	"time"
 
@@ -56,7 +58,8 @@ func TestDrainBuffer(t *testing.T) {
 			// initial setup
 			ctx, cancel := context.WithCancel(context.Background())
 			persistor := NewConfigMapPersistor(configMapClient, cmName, cmNS)
-			interf := NewDrainBuffer(ctx, persistor, tt.Clock, logger)
+			recorder := kubernetes.NewEventRecorder(record.NewFakeRecorder(1000))
+			interf := NewDrainBuffer(ctx, persistor, tt.Clock, logger, recorder, nil, nil, time.Second)
 			drainBuffer := interf.(*drainBufferImpl)
 			drainBuffer.Initialize(ctx)
 
@@ -72,7 +75,7 @@ func TestDrainBuffer(t *testing.T) {
 			ctx, cancel = context.WithCancel(context.Background())
 			defer cancel()
 			persistor = NewConfigMapPersistor(configMapClient, cmName, cmNS)
-			interf = NewDrainBuffer(ctx, persistor, tt.Clock, logger)
+			interf = NewDrainBuffer(ctx, persistor, tt.Clock, logger, recorder, nil, nil, time.Second)
 			drainBuffer = interf.(*drainBufferImpl)
 
 			// Move clock forward & trigger cleanup

--- a/internal/drain_runner/fake.go
+++ b/internal/drain_runner/fake.go
@@ -3,6 +3,7 @@ package drain_runner
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/tools/record"
 	"time"
 
 	"k8s.io/client-go/kubernetes/fake"
@@ -68,7 +69,8 @@ func (opts *FakeOptions) ApplyDefaults() error {
 		fakeClient := fake.NewSimpleClientset()
 		configMapClient := fakeClient.CoreV1().ConfigMaps("default")
 		persistor := drainbuffer.NewConfigMapPersistor(configMapClient, "fake-buffer", "default")
-		opts.DrainBuffer = drainbuffer.NewDrainBuffer(context.Background(), persistor, opts.Clock, *opts.Logger)
+		recorder := kubernetes.NewEventRecorder(record.NewFakeRecorder(1000))
+		opts.DrainBuffer = drainbuffer.NewDrainBuffer(context.Background(), persistor, opts.Clock, *opts.Logger, recorder, nil, nil, kubernetes.DefaultDrainBuffer)
 	}
 	return nil
 }

--- a/internal/drain_runner/info.go
+++ b/internal/drain_runner/info.go
@@ -11,6 +11,7 @@ const (
 
 type DataInfo struct {
 	ProcessingDuration time.Duration
+	DrainBufferTill    time.Time
 }
 
 func (d *DataInfo) Import(i interface{}) error {

--- a/internal/drain_runner/runner_test.go
+++ b/internal/drain_runner/runner_test.go
@@ -136,7 +136,7 @@ func TestDrainRunner(t *testing.T) {
 				Objects: []runtime.Object{tt.Node},
 				Indexes: []k8sclient.WithIndex{
 					func(_ client.Client, cache cachecr.Cache) error {
-						return groups.InitSchedulingGroupIndexer(cache, groups.NewGroupKeyFromNodeMetadata([]string{"key"}, nil, ""))
+						return groups.InitSchedulingGroupIndexer(cache, groups.NewGroupKeyFromNodeMetadata(kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""))
 					},
 				},
 			})

--- a/internal/drain_runner/runner_test.go
+++ b/internal/drain_runner/runner_test.go
@@ -137,7 +137,7 @@ func TestDrainRunner(t *testing.T) {
 				Objects: []runtime.Object{tt.Node},
 				Indexes: []k8sclient.WithIndex{
 					func(_ client.Client, cache cachecr.Cache) error {
-						return groups.InitSchedulingGroupIndexer(cache, groups.NewGroupKeyFromNodeMetadata(testLogger, kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""))
+						return groups.InitSchedulingGroupIndexer(cache, groups.NewGroupKeyFromNodeMetadata(nil, testLogger, kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""))
 					},
 				},
 			})

--- a/internal/drain_runner/runner_test.go
+++ b/internal/drain_runner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/go-logr/zapr"
 	"testing"
 	"time"
 
@@ -128,7 +129,7 @@ func TestDrainRunner(t *testing.T) {
 			ShoulHaveTaint: false,
 		},
 	}
-
+	testLogger := zapr.NewLogger(zap.NewNop())
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 
@@ -136,7 +137,7 @@ func TestDrainRunner(t *testing.T) {
 				Objects: []runtime.Object{tt.Node},
 				Indexes: []k8sclient.WithIndex{
 					func(_ client.Client, cache cachecr.Cache) error {
-						return groups.InitSchedulingGroupIndexer(cache, groups.NewGroupKeyFromNodeMetadata(kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""))
+						return groups.InitSchedulingGroupIndexer(cache, groups.NewGroupKeyFromNodeMetadata(testLogger, kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""))
 					},
 				},
 			})

--- a/internal/groups/group_from_pod.go
+++ b/internal/groups/group_from_pod.go
@@ -1,0 +1,113 @@
+package groups
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/planetlabs/draino/internal/kubernetes"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type GroupFromPod struct {
+	kclient   client.Client
+	logger    logr.Logger
+	keyGetter GroupKeyGetter
+	podFilter kubernetes.PodFilterFunc
+
+	podToNodeCache cache.ThreadSafeStore // map[podName]NodeName, used to report on node in case of pod deletion
+
+	hasSyncedFunc func() bool
+}
+
+func NewGroupFromPod(
+	kclient client.Client,
+	logger logr.Logger,
+	keyGetter GroupKeyGetter,
+	podFilter kubernetes.PodFilterFunc,
+	hasSyncedFunc func() bool,
+) *GroupFromPod {
+	return &GroupFromPod{
+		kclient:        kclient,
+		logger:         logger,
+		keyGetter:      keyGetter,
+		podFilter:      podFilter,
+		hasSyncedFunc:  hasSyncedFunc,
+		podToNodeCache: cache.NewThreadSafeStore(nil, nil),
+	}
+}
+
+// Reconcile register the pod to report possible group override
+func (r *GroupFromPod) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !r.hasSyncedFunc() {
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: 5 * time.Second,
+		}, nil
+	}
+	pod := &v1.Pod{}
+	if err := r.kclient.Get(ctx, req.NamespacedName, pod); err != nil {
+		if errors.IsNotFound(err) {
+			if nodeName, ok := r.podToNodeCache.Get(req.String()); ok {
+				result, errKG := r.notifyKeyGetter(ctx, nodeName.(string))
+				if errKG != nil {
+					return result, errKG
+				}
+				r.podToNodeCache.Delete(req.String())
+			}
+			return reconcile.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get Pod Fails: %v", err)
+	}
+	if pass, _, errFilter := r.podFilter(*pod); !pass {
+		if errFilter != nil {
+			r.logger.Error(errFilter, "failed to filter pods")
+		}
+		return ctrl.Result{}, nil
+	}
+
+	nodeName := pod.Spec.NodeName
+	if nodeName == "" {
+		return ctrl.Result{}, nil
+	}
+	r.podToNodeCache.Add(req.String(), nodeName)
+	return r.notifyKeyGetter(ctx, nodeName)
+}
+
+func (r *GroupFromPod) notifyKeyGetter(ctx context.Context, nodeName string) (ctrl.Result, error) {
+	node := &v1.Node{}
+	if err := r.kclient.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get Node Fails: %v", err)
+	}
+
+	r.keyGetter.CheckGroupOverride(node)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager setups the controller with goroutine and predicates
+func (r *GroupFromPod) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
+		For(&v1.Pod{}).
+		WithEventFilter(
+			predicate.Funcs{
+				CreateFunc:  func(evt event.CreateEvent) bool { return true },
+				DeleteFunc:  func(event.DeleteEvent) bool { return true },
+				GenericFunc: func(event.GenericEvent) bool { return false },
+				UpdateFunc:  func(evt event.UpdateEvent) bool { return true },
+			},
+		).
+		Complete(r)
+}

--- a/internal/groups/key_test.go
+++ b/internal/groups/key_test.go
@@ -1,9 +1,17 @@
 package groups
 
 import (
+	"context"
+	"github.com/go-logr/zapr"
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"testing"
 )
 
@@ -12,6 +20,7 @@ func TestGroupKeyFromMetadata_GetGroupKey(t *testing.T) {
 		name                       string
 		labelsKeys                 []string
 		annotationKeys             []string
+		objects                    []runtime.Object
 		groupOverrideAnnotationKey string
 		node                       *v1.Node
 		want                       GroupKey
@@ -64,10 +73,54 @@ func TestGroupKeyFromMetadata_GetGroupKey(t *testing.T) {
 			},
 			want: GroupKey("zzz#xxx"),
 		},
+		{
+			name:                       "pod override",
+			labelsKeys:                 []string{"L1", "L2"},
+			groupOverrideAnnotationKey: "ZZZ",
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:        "the-node",
+					Labels:      nil,
+					Annotations: nil,
+				},
+			},
+			objects: []runtime.Object{
+				&v1.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:        "pod1",
+						Annotations: map[string]string{"A3": "a3", "ZZZ": "zzz,xxx"},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "the-node",
+					},
+				},
+			},
+			want: GroupKey("zzz#xxx"),
+		},
 	}
+	testLogger := zapr.NewLogger(zap.NewNop())
 	for _, tt := range tests {
+
+		wrapper, err := k8sclient.NewFakeClient(k8sclient.FakeConf{Objects: tt.objects})
+		assert.NoError(t, err)
+
+		fakeKubeClient := fakeclient.NewSimpleClientset(tt.objects...)
+		store, closeFunc := kubernetes.RunStoreForTest(context.Background(), fakeKubeClient)
+		defer closeFunc()
+
+		fakeIndexer, err := index.New(wrapper.GetManagerClient(), wrapper.GetCache(), testLogger)
+		assert.NoError(t, err)
+
+		ch := make(chan struct{})
+		defer close(ch)
+		wrapper.Start(ch)
+
+		if err != nil {
+			t.Fatalf("can't create fakeIndexer: %#v", err)
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGroupKeyFromNodeMetadata(tt.labelsKeys, tt.annotationKeys, tt.groupOverrideAnnotationKey)
+			g := NewGroupKeyFromNodeMetadata(kubernetes.NoopEventRecorder{}, fakeIndexer, store, tt.labelsKeys, tt.annotationKeys, tt.groupOverrideAnnotationKey)
 			if got := g.GetGroupKey(tt.node); got != tt.want {
 				t.Errorf("GetGroupKey() = %v, want %v", got, tt.want)
 			}
@@ -128,5 +181,127 @@ func TestGroupKeyFromMetadata_ValidateGroupKey(t *testing.T) {
 			assert.Equalf(t, tt.wantValid, gotValid, "ValidateGroupKey Valid field")
 			assert.Equalf(t, tt.wantReason, gotReason, "Reason field")
 		})
+	}
+}
+
+func TestGroupKeyFromMetadata_GetGroupKeyFromPods(t *testing.T) {
+	tests := []struct {
+		name                       string
+		objects                    []runtime.Object
+		groupOverrideAnnotationKey string
+		node                       *v1.Node
+		want                       GroupKey
+		override                   bool
+	}{
+		{
+			name:                       "pod override",
+			groupOverrideAnnotationKey: "ZZZ",
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:        "the-node",
+					Labels:      nil,
+					Annotations: nil,
+				},
+			},
+			objects: []runtime.Object{
+				&v1.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:        "pod1",
+						Annotations: map[string]string{"A3": "a3", "ZZZ": "zzz,xxx"},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "the-node",
+					},
+				},
+			},
+			want:     GroupKey("zzz#xxx"),
+			override: true,
+		},
+		{
+			name:                       "pod override double, reject",
+			groupOverrideAnnotationKey: "ZZZ",
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:        "the-node",
+					Labels:      nil,
+					Annotations: nil,
+				},
+			},
+			objects: []runtime.Object{
+				&v1.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:        "pod1",
+						Annotations: map[string]string{"A3": "a3", "ZZZ": "zzz,xxx"},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "the-node",
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:        "pod2",
+						Annotations: map[string]string{"A3": "a3", "ZZZ": "zzz,yyy"},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "the-node",
+					},
+				},
+			},
+			want:     GroupKey(""),
+			override: false,
+		},
+		{
+			name:                       "no override",
+			groupOverrideAnnotationKey: "ZZZ",
+			node: &v1.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:        "the-node",
+					Labels:      nil,
+					Annotations: nil,
+				},
+			},
+			objects: []runtime.Object{
+				&v1.Pod{
+					ObjectMeta: meta.ObjectMeta{
+						Name:        "pod1",
+						Annotations: map[string]string{"A3": "a3", "OTHER": "zzz,xxx"},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "the-node",
+					},
+				},
+			},
+			want:     GroupKey(""),
+			override: false,
+		},
+	}
+	testLogger := zapr.NewLogger(zap.NewNop())
+	for _, tt := range tests {
+
+		wrapper, err := k8sclient.NewFakeClient(k8sclient.FakeConf{Objects: tt.objects})
+		assert.NoError(t, err)
+
+		fakeKubeClient := fakeclient.NewSimpleClientset(tt.objects...)
+		store, closeFunc := kubernetes.RunStoreForTest(context.Background(), fakeKubeClient)
+		defer closeFunc()
+
+		fakeIndexer, err := index.New(wrapper.GetManagerClient(), wrapper.GetCache(), testLogger)
+		assert.NoError(t, err)
+
+		ch := make(chan struct{})
+		defer close(ch)
+		wrapper.Start(ch)
+
+		if err != nil {
+			t.Fatalf("can't create fakeIndexer: %#v", err)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGroupKeyFromNodeMetadata(kubernetes.NoopEventRecorder{}, fakeIndexer, store, nil, nil, tt.groupOverrideAnnotationKey).(*GroupKeyFromMetadata)
+			gotValue, override := g.getGroupKeyFromPods(tt.node)
+			assert.Equalf(t, tt.want, gotValue, "groupKey value")
+			assert.Equalf(t, tt.override, override, "Override")
+		})
+
 	}
 }

--- a/internal/groups/reconciler_test.go
+++ b/internal/groups/reconciler_test.go
@@ -66,7 +66,7 @@ func TestNewGroupRegistry(t *testing.T) {
 			name:                  "test1",
 			drainFactory:          NewTestRunnerFactory(),
 			drainCandidateFactory: NewTestRunnerFactory(),
-			keyGetter:             NewGroupKeyFromNodeMetadata(testLogger, kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""),
+			keyGetter:             NewGroupKeyFromNodeMetadata(nil, testLogger, kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""),
 			runCount: map[GroupKey]int{
 				"g1": 1,
 				"g2": 1,

--- a/internal/groups/reconciler_test.go
+++ b/internal/groups/reconciler_test.go
@@ -2,6 +2,7 @@ package groups
 
 import (
 	"context"
+	"github.com/planetlabs/draino/internal/kubernetes"
 	"sync"
 	"testing"
 	"time"
@@ -64,7 +65,7 @@ func TestNewGroupRegistry(t *testing.T) {
 			name:                  "test1",
 			drainFactory:          NewTestRunnerFactory(),
 			drainCandidateFactory: NewTestRunnerFactory(),
-			keyGetter:             NewGroupKeyFromNodeMetadata([]string{"key"}, nil, ""),
+			keyGetter:             NewGroupKeyFromNodeMetadata(kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""),
 			runCount: map[GroupKey]int{
 				"g1": 1,
 				"g2": 1,

--- a/internal/groups/reconciler_test.go
+++ b/internal/groups/reconciler_test.go
@@ -2,12 +2,13 @@ package groups
 
 import (
 	"context"
+	"github.com/go-logr/zapr"
 	"github.com/planetlabs/draino/internal/kubernetes"
+	"go.uber.org/zap"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -52,7 +53,7 @@ var _ RunnerFactory = &TestRunnerFactory{}
 func TestNewGroupRegistry(t *testing.T) {
 
 	RegisterMetrics(prometheus.NewRegistry())
-
+	testLogger := zapr.NewLogger(zap.NewNop())
 	tests := []struct {
 		name                  string
 		drainFactory          RunnerFactory
@@ -65,7 +66,7 @@ func TestNewGroupRegistry(t *testing.T) {
 			name:                  "test1",
 			drainFactory:          NewTestRunnerFactory(),
 			drainCandidateFactory: NewTestRunnerFactory(),
-			keyGetter:             NewGroupKeyFromNodeMetadata(kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""),
+			keyGetter:             NewGroupKeyFromNodeMetadata(testLogger, kubernetes.NoopEventRecorder{}, nil, nil, []string{"key"}, nil, ""),
 			runCount: map[GroupKey]int{
 				"g1": 1,
 				"g2": 1,
@@ -95,8 +96,6 @@ func TestNewGroupRegistry(t *testing.T) {
 			},
 		},
 	}
-
-	testLogger := logr.New(logr.Discard().GetSink())
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -51,6 +51,7 @@ const (
 	statefulsetName = "coolStatefulSet"
 	deploymentName  = "coolDeployment"
 	kindDeployment  = "Deployment"
+	kindReplicaSet  = "ReplicaSet"
 )
 
 var (

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -21,12 +21,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/DataDog/compute-go/logs"
+	"github.com/go-logr/logr"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oklog/run"
 	"go.opencensus.io/stats"
@@ -417,6 +418,184 @@ func GetAnnotationFromPodOrController(annotationKey string, pod *core.Pod, store
 	return "", false
 }
 
+type AnnotationSearchResultOnPod[T comparable] struct {
+	Pod          *core.Pod `json:"-"`
+	PodId        string    `json:"pod,omitempty"`
+	Value        T         `json:"value"`
+	errorConv    error     // this is private because it can and shouldn't be serialized for diagnostics
+	ErrorConvStr string    `json:"errorConversion,omitempty"`
+	OnController bool      `json:"onController,omitempty"`
+}
+type AnnotationSearchResult[T comparable] struct {
+	Value        T                                           `json:"value"`
+	Found        bool                                        `json:"found"`
+	errorConv    error                                       // this is private because it can and shouldn't be serialized for diagnostics
+	ErrorConvStr string                                      `json:"errorConversion,omitempty"`
+	Node         *core.Node                                  `json:"-"`
+	PodResults   map[string][]AnnotationSearchResultOnPod[T] `json:"pods,omitempty"`
+}
+
+type SerializationAliasAnnotationSearchResultOnPod[T comparable] AnnotationSearchResultOnPod[T]
+type SerializationAliasAnnotationSearchResult[T comparable] AnnotationSearchResult[T]
+
+func (a *AnnotationSearchResultOnPod[T]) MarshalJSON() ([]byte, error) {
+	if a.errorConv != nil {
+		a.ErrorConvStr = a.errorConv.Error()
+	}
+	if a.Pod != nil {
+		a.PodId = a.Pod.Namespace + "/" + a.Pod.Name
+	}
+	return json.Marshal(SerializationAliasAnnotationSearchResultOnPod[T](*a))
+}
+func (a *AnnotationSearchResult[T]) MarshalJSON() ([]byte, error) {
+	if a.errorConv != nil {
+		a.ErrorConvStr = a.errorConv.Error()
+	}
+	return json.Marshal(SerializationAliasAnnotationSearchResult[T](*a))
+}
+func (a *AnnotationSearchResult[T]) addPodResult(k string, r AnnotationSearchResultOnPod[T]) {
+	if a.PodResults == nil {
+		a.PodResults = map[string][]AnnotationSearchResultOnPod[T]{}
+	}
+	a.PodResults[k] = append(a.PodResults[k], r)
+}
+
+func (a *AnnotationSearchResult[T]) AsSlice() (out []T) {
+	if !a.Found {
+		return nil
+	}
+	if a.Node != nil {
+		out = append(out, a.Value)
+	}
+	for _, v := range a.PodResults {
+		if a.Node != nil { // check that it is not a dupe with node value if any
+			if v[0].Value == a.Value {
+				continue
+			}
+		}
+		out = append(out, v[0].Value)
+	}
+	return
+}
+
+func (a *AnnotationSearchResult[T]) IsValueUnique() bool {
+	if !a.Found {
+		return false
+	}
+	if len(a.PodResults) > 1 {
+		return false
+	}
+	if len(a.PodResults) == 0 {
+		return true
+	}
+	for _, v := range a.PodResults {
+		if len(v) > 0 && a.Value != v[0].Value {
+			return false
+		}
+	}
+	return true
+}
+
+// PruneErrors return a new search result with all errors removed. If handler functions for error are provided, they are called for each error that is pruned
+// The boolean that is return is true is No error was found and pruned.
+// The receiver is not modified.
+func (a *AnnotationSearchResult[T]) PruneErrors(nodeErrFunc func(node *core.Node, err error), podErrFunc func(pod *core.Pod, err error)) (AnnotationSearchResult[T], bool) {
+	noError := true
+	result := AnnotationSearchResult[T]{
+		Found: a.Found,
+	}
+	if a.errorConv != nil {
+		noError = false
+		if nodeErrFunc != nil && a.Node != nil {
+			nodeErrFunc(a.Node, a.errorConv)
+		}
+	} else {
+		result.Found = true
+		result.Node = a.Node
+		result.Value = a.Value
+	}
+
+	if a.PodResults == nil {
+		return result, noError
+	}
+	result.PodResults = map[string][]AnnotationSearchResultOnPod[T]{}
+	for k, pr := range result.PodResults {
+		for _, v := range pr {
+			if v.errorConv != nil {
+				noError = false
+				if podErrFunc != nil && v.Pod != nil {
+					podErrFunc(v.Pod, v.errorConv)
+				}
+			} else {
+				result.Found = true
+				result.PodResults[k] = append(result.PodResults[k], v)
+			}
+		}
+
+	}
+	if len(result.PodResults) == 0 {
+		result.PodResults = nil
+	}
+	return result, noError
+}
+
+func GetAnnotationFromNodeAndThenPodOrController[T comparable](ctx context.Context, podIndexer index.PodIndexer, store RuntimeObjectStore, converter func(string) (T, error), annotationKey string, node *core.Node, stopIfFoundOnNode, stopIfFoundOnPod bool) (AnnotationSearchResult[T], error) {
+	var result AnnotationSearchResult[T]
+	if node.Annotations != nil {
+		if valueStr, ok := node.Annotations[annotationKey]; ok {
+			result.Value, result.errorConv = converter(valueStr)
+			result.Found = (result.errorConv == nil)
+			if stopIfFoundOnNode {
+				return result, nil
+			}
+		}
+	}
+	if podIndexer == nil {
+		return result, nil
+	}
+
+	pods, err := podIndexer.GetPodsByNode(ctx, node.Name)
+	if err != nil {
+		return result, err
+	}
+	for i := range pods {
+		pod := pods[i]
+		// Check directly on the pod and return if any value
+		if pod.Annotations != nil {
+			if valueStr, ok := pod.Annotations[annotationKey]; ok {
+				ar := AnnotationSearchResultOnPod[T]{
+					Pod: pod,
+				}
+				ar.Value, ar.errorConv = converter(valueStr)
+				result.addPodResult(valueStr, ar)
+				if ar.errorConv == nil {
+					result.Found = true
+				}
+				if stopIfFoundOnPod {
+					continue // we won't explore the controller
+				}
+			}
+		}
+
+		if ctrl, found := GetControllerForPod(pod, store); found {
+			if valueStr, ok := ctrl.GetAnnotations()[annotationKey]; ok {
+				ar := AnnotationSearchResultOnPod[T]{
+					Pod:          pod,
+					OnController: true,
+				}
+				ar.Value, ar.errorConv = converter(valueStr)
+				result.addPodResult(valueStr, ar)
+				if ar.errorConv == nil {
+					result.Found = true
+				}
+
+				continue
+			}
+		}
+	}
+	return result, nil
+}
+
 // GetControllerForPod for the moment it handles only statefulSets and deployments controller
 func GetControllerForPod(pod *core.Pod, store RuntimeObjectStore) (ctrl metav1.Object, found bool) {
 	for _, r := range pod.OwnerReferences {
@@ -487,5 +666,7 @@ func LogForVerboseNode(logger *zap.Logger, node *core.Node, msg string, fields .
 func LogrForVerboseNode(logger logr.Logger, node *core.Node, msg string, fields ...interface{}) {
 	if node.Annotations["draino/logs"] == "verbose" {
 		logger.Info(msg, append(fields, "node", node.Name))
+	} else {
+		logger.V(logs.ZapDebug).Info(msg, append(fields, "node", node.Name))
 	}
 }

--- a/internal/kubernetes/util_test.go
+++ b/internal/kubernetes/util_test.go
@@ -1,7 +1,18 @@
 package kubernetes
 
 import (
+	"context"
+	"fmt"
+	"github.com/go-logr/zapr"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"reflect"
+	"sort"
 	"testing"
 
 	openapi_v2 "github.com/google/gnostic/openapiv2"
@@ -238,6 +249,340 @@ func TestGetAPIResourcesForGVK(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetAPIResourcesForGVK() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestGetAnnotationFromNodeAndThenPodOrController(t *testing.T) {
+	testKey := "testKey"
+	testValue := "testValue"
+	nodeNoAnnotation := &core.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+		},
+	}
+	nodeNoKey := &core.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+			Name:        "node1",
+		},
+	}
+	nodeWithKey := &core.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node1",
+			Annotations: map[string]string{testKey: testValue},
+		},
+	}
+	podNoAnnotation := &core.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-annotation",
+			Namespace: "ns",
+			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
+				Controller: &isController,
+				Kind:       kindReplicaSet,
+				Name:       deploymentName + "-xyz",
+				APIVersion: "apps/v1",
+			}},
+		},
+		Spec: core.PodSpec{
+			NodeName: "node1",
+		},
+	}
+	podNoKey := &core.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "no-key",
+			Namespace:   "ns",
+			Annotations: map[string]string{},
+			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
+				Controller: &isController,
+				Kind:       kindReplicaSet,
+				Name:       deploymentName + "-xyz",
+				APIVersion: "apps/v1",
+			}},
+		},
+		Spec: core.PodSpec{
+			NodeName: "node1",
+		},
+	}
+	podWithKey := &core.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "with-key",
+			Namespace:   "ns",
+			Annotations: map[string]string{testKey: testValue},
+			OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
+				Controller: &isController,
+				Kind:       kindReplicaSet,
+				Name:       deploymentName + "-xyz",
+				APIVersion: "apps/v1",
+			}},
+		},
+		Spec: core.PodSpec{
+			NodeName: "node1",
+		},
+	}
+	DeploymentNoKey := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: "ns",
+		},
+	}
+	DeploymentWithKey := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        deploymentName,
+			Namespace:   "ns",
+			Annotations: map[string]string{testKey: testValue},
+		},
+	}
+
+	pods := map[string]*core.Pod{
+		podWithKey.Name:      podWithKey,
+		podNoKey.Name:        podNoKey,
+		podNoAnnotation.Name: podNoAnnotation,
+	}
+
+	tests := []struct {
+		name    string
+		node    *core.Node
+		objects []runtime.Object
+		want    AnnotationSearchResult[string]
+		wantErr bool
+	}{
+		{
+			name: "node no annotation",
+			node: nodeNoAnnotation,
+			want: AnnotationSearchResult[string]{
+				Found: false,
+			},
+		},
+		{
+			name: "node no key",
+			node: nodeNoKey,
+			want: AnnotationSearchResult[string]{
+				Found: false,
+			},
+		},
+		{
+			name: "node with key",
+			node: nodeWithKey,
+			want: AnnotationSearchResult[string]{
+				Value: testValue,
+				Found: true,
+			},
+		},
+		{
+			name: "node,pod no annotation, controller no key",
+			node: nodeNoAnnotation,
+			objects: []runtime.Object{
+				podNoAnnotation, DeploymentNoKey,
+			},
+			want: AnnotationSearchResult[string]{
+				Found: false,
+			},
+		},
+		{
+			name: "node,pod,controller no key",
+			node: nodeNoKey,
+			want: AnnotationSearchResult[string]{
+				Found: false,
+			},
+			objects: []runtime.Object{
+				podNoKey, DeploymentNoKey,
+			},
+		},
+		{
+			name: "node,pod,no key and controller with key",
+			node: nodeNoKey,
+			want: AnnotationSearchResult[string]{
+				Found: true,
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{
+					testValue: {{
+						Value:        testValue,
+						Pod:          podNoKey,
+						OnController: true,
+					}},
+				},
+			},
+			objects: []runtime.Object{
+				podNoKey, DeploymentWithKey, nodeNoKey,
+			},
+		},
+		{
+			name: "node no key, pod,controller with key",
+			node: nodeNoKey,
+			want: AnnotationSearchResult[string]{
+				Found: true,
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{
+					testValue: {{
+						Value:        testValue,
+						Pod:          podWithKey,
+						OnController: false,
+					}},
+				},
+			},
+			objects: []runtime.Object{
+				podWithKey, DeploymentWithKey,
+			},
+		},
+	}
+	testLogger := zapr.NewLogger(zap.NewNop())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			wrapper, err := k8sclient.NewFakeClient(k8sclient.FakeConf{Objects: tt.objects})
+			assert.NoError(t, err)
+
+			fakeKubeClient := fakeclient.NewSimpleClientset(tt.objects...)
+			store, closeFunc := RunStoreForTest(context.Background(), fakeKubeClient)
+			defer closeFunc()
+
+			fakeIndexer, err := index.New(wrapper.GetManagerClient(), wrapper.GetCache(), testLogger)
+			assert.NoError(t, err)
+
+			ch := make(chan struct{})
+			defer close(ch)
+			wrapper.Start(ch)
+
+			if err != nil {
+				t.Fatalf("can't create fakeIndexer: %#v", err)
+			}
+
+			got, err := GetAnnotationFromNodeAndThenPodOrController(context.Background(), fakeIndexer, store, func(s string) (string, error) { return s, nil }, testKey, tt.node, true, true)
+			if tt.wantErr != (err != nil) {
+				fmt.Printf("%sGetAnnotationFromNodeAndThenPodOrController() ERR: %#v", tt.name, err)
+				t.Failed()
+			}
+			if err != nil {
+				return
+			}
+
+			// be sure that we are using the same pointer for comparison
+			for _, v := range got.PodResults {
+				for i := range v {
+					v[i].Pod = pods[v[i].Pod.Name]
+				}
+			}
+			for _, v := range tt.want.PodResults {
+				for i := range v {
+					v[i].Pod = pods[v[i].Pod.Name]
+				}
+			}
+
+			assert.Equalf(t, tt.want, got, "GetAnnotationFromNodeAndThenPodOrController()")
+		})
+	}
+}
+
+func TestAnnotationSearchResult_IsValueUnique(t *testing.T) {
+	tests := []struct {
+		name string
+		ar   AnnotationSearchResult[string]
+		want bool
+	}{
+		{
+			name: "empty",
+			ar:   AnnotationSearchResult[string]{},
+			want: false,
+		},
+		{
+			name: "node level only",
+			ar: AnnotationSearchResult[string]{
+				Found: true,
+				Value: "",
+				Node:  &core.Node{},
+			},
+			want: true,
+		},
+		{
+			name: "pod only and unique",
+			ar: AnnotationSearchResult[string]{
+				Found:      true,
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{"": {{Value: ""}}},
+			},
+			want: true,
+		},
+		{
+			name: "pod only not unique",
+			ar: AnnotationSearchResult[string]{
+				Found:      true,
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{"": {{Value: ""}}, "a": {{Value: "a"}}},
+			},
+			want: false,
+		},
+		{
+			name: "pod and node unique",
+			ar: AnnotationSearchResult[string]{
+				Found:      true,
+				Value:      "a",
+				Node:       &core.Node{},
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{"a": {{Value: "a"}}},
+			},
+			want: true,
+		},
+		{
+			name: "pod and node not unique",
+			ar: AnnotationSearchResult[string]{
+				Found:      true,
+				Value:      "a",
+				Node:       &core.Node{},
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{"b": {{Value: "b"}}},
+			},
+			want: false,
+		},
+		{
+			name: "pod and node not unique 2",
+			ar: AnnotationSearchResult[string]{
+				Found:      true,
+				Value:      "a",
+				Node:       &core.Node{},
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{"a": {{Value: "a"}}, "b": {{Value: "b"}}},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tt.ar.IsValueUnique(), "IsValueUnique()")
+		})
+	}
+}
+
+func TestAnnotationSearchResult_AsSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		ar      AnnotationSearchResult[string]
+		wantOut []string
+	}{
+		{
+			name: "dupe node pod",
+			ar: AnnotationSearchResult[string]{
+				Found:      true,
+				Value:      "a",
+				Node:       &core.Node{},
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{"a": {{Value: "a"}}, "b": {{Value: "b"}}},
+			},
+			wantOut: []string{"a", "b"},
+		},
+		{
+			name: "pod only",
+			ar: AnnotationSearchResult[string]{
+				Found:      true,
+				PodResults: map[string][]AnnotationSearchResultOnPod[string]{"a": {{Value: "a"}}, "b": {{Value: "b"}}, "c": {{Value: "c"}}},
+			},
+			wantOut: []string{"a", "b", "c"},
+		},
+		{
+			name: "nil",
+			ar: AnnotationSearchResult[string]{
+				Found: false,
+			},
+			wantOut: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sort.Strings(tt.wantOut)
+			sort.Strings(tt.ar.AsSlice())
+			assert.Equalf(t, tt.wantOut, tt.ar.AsSlice(), "AsSlice()")
 		})
 	}
 }


### PR DESCRIPTION
It is a big PR 3 block in there:
- The func to get annotation on node/pods/controller, it is named GetAnnotationFromNodeAndThenPodOrController, it should be generic enough to cope with multiple needs (getting whatever type, duration, int, string, .... basically anything that implements `comparable`). There is the serialization part of the result that is interesting with a trick on type Aliasing to convert errors and objects in string on the fly at serialization time
- A new command to diagnostics all the nodes of a group at once, table output. `draino groups --group-name={name} nodes`
- And of course the implementation of `drainBuffer` that we were missing

