### PR TITLE
create a deep copy of the given node, before executing the patch

### DIFF
--- a/internal/kubernetes/k8sclient/kube_patch.go
+++ b/internal/kubernetes/k8sclient/kube_patch.go
@@ -80,7 +80,7 @@ func (p *JSONAnnotationPatch) Data(obj client.Object) ([]byte, error) {
 }
 
 // --------------------------------------------
-// JSON Patches
+// Merge patches
 // --------------------------------------------
 type AnnotationPatch struct {
 	Metadata struct {
@@ -148,7 +148,11 @@ func PatchNode(ctx context.Context, kclient kubernetes.Interface, nodeName strin
 }
 
 func PatchNodeCR(ctx context.Context, client client.Client, node *corev1.Node, patch client.Patch) error {
-	return client.Patch(ctx, node, patch)
+	// The client.Patch method is automatically updating the given node.
+	// As the pointer is used in other places, it will cause concurrent map read / write panics
+	// In order to prevent this, we'll create a deep copy of the node and pass it to the client.Patch.
+	freshNode := node.DeepCopy()
+	return client.Patch(ctx, freshNode, patch)
 }
 
 func PatchNodeAnnotationKey(ctx context.Context, kclient kubernetes.Interface, nodeName string, key string, value string) error {


### PR DESCRIPTION
This will fix the concurrency issue, which is causing kernel panics related to concurrent map reads & writes.

Here you can find an example script to very the assumption
https://gist.github.com/dhenkel92/251299baafc2b8b67fd64510c3e327df