### PR TITLE
increase eviction++ timeout to 20s

### DIFF
--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -862,7 +862,7 @@ func (d *APICordonDrainer) evictWithOperatorAPI(ctx context.Context, url string,
 				logger.Info("Using token-audience parameter", zap.String("token-audience", tokenAudience))
 			}
 
-			client = &http.Client{Transport: roundTripper, Timeout: 10 * time.Second}
+			client = &http.Client{Transport: roundTripper, Timeout: 20 * time.Second}
 			logger.Info("calling eviction++", zap.String("url", urlParsed.String()))
 			req, err := http.NewRequest("POST", urlParsed.String(), GetEvictionJsonPayload(evictionPayload))
 			req = req.WithContext(ctx)


### PR DESCRIPTION
During some checkups, I’ve noticed that quite some requests to the logs-indexold-coordinator eviction++ endpoint are timing out. [(Logs)](https://app.datadoghq.com/logs?query=service%3Adraino%20message%3A%22custom%20eviction%20endpoint%20response%20error%22%20&agg_q=&cols=kube_cluster_name%2C%40error.message&index=&messageDisplay=inline&sort_m=&sort_t=&stream_sort=time%2Cdesc&top_n=&top_o=&viz=stream&x_missing=&from_ts=1675767396993&to_ts=1675853796993&live=true)

After some discussion with the event-storage-routing team with the following answers: 
1) They want to get rid of this coordinator
2) They have a static timeout of 15s on their side as well.

As this is the only application which is failing regularly, we've decided to keep the static value and just increase it. This will reduce the amount of errors and we can revisit the topic in the future again.