### PR TITLE
remove _total suffix from counter metric

### DIFF
--- a/internal/drain_runner/metrics.go
+++ b/internal/drain_runner/metrics.go
@@ -15,7 +15,7 @@ var (
 		DrainedNodes *prometheus.CounterVec
 	}{
 		DrainedNodes: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "draino_drained_nodes_total",
+			Name: "draino_drained_nodes",
 			Help: "Number of nodes drained.",
 		}, []string{kubernetes.TagResult.Name(), kubernetes.TagFailureCause.Name(), kubernetes.TagConditions.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name()}),
 	}


### PR DESCRIPTION
> Note: Starting in Datadog Agent v7.32.0, in adherence to the [OpenMetrics specification standard](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#suffixes), counter names ending in _total must be specified without the _total suffix. For example, to collect promhttp_metric_handler_requests_total, specify the metric name promhttp_metric_handler_requests. This submits to Datadog the metric name appended with .count, promhttp_metric_handler_requests.count.