### PR TITLE
Allow multiple nodes in a group to be drained

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -367,6 +367,7 @@ func main() {
 			candidate_runner.WithSharedIndexInformer(indexer),
 			candidate_runner.WithEventRecorder(eventRecorder),
 			candidate_runner.WithMaxSimultaneousCandidates(1), // TODO should we move that to something that can be customized per user
+			candidate_runner.WithMaxSimultaneousDrained(5),    // TODO should we move that to something that can be customized per user
 			candidate_runner.WithFilter(filterFactory.BuildCandidateFilter()),
 			candidate_runner.WithDrainSimulator(simulator),
 			candidate_runner.WithNodeSorters(sorters),

--- a/internal/candidate_runner/config.go
+++ b/internal/candidate_runner/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	clock                     clock.Clock
 	rerunEvery                time.Duration
 	maxSimultaneousCandidates int
+	maxSimultaneousDrained    int
 	dryRun                    bool
 	nodeIteratorFactory       NodeIteratorFactory
 }
@@ -50,6 +51,7 @@ func NewConfig() *Config {
 		rerunEvery:                time.Second,
 		dryRun:                    true,
 		maxSimultaneousCandidates: 1,
+		maxSimultaneousDrained:    5,
 		nodeIteratorFactory: func(nodes []*corev1.Node, sorters NodeSorters) scheduler.ItemProvider[*corev1.Node] {
 			return scheduler.NewSortingTreeWithInitialization(nodes, sorters)
 		},
@@ -131,6 +133,12 @@ func WithEventRecorder(er kubernetes.EventRecorder) WithOption {
 func WithMaxSimultaneousCandidates(maxSimultaneousCandidates int) WithOption {
 	return func(conf *Config) {
 		conf.maxSimultaneousCandidates = maxSimultaneousCandidates
+	}
+}
+
+func WithMaxSimultaneousDrained(maxSimultaneousDrained int) WithOption {
+	return func(conf *Config) {
+		conf.maxSimultaneousDrained = maxSimultaneousDrained
 	}
 }
 

--- a/internal/candidate_runner/factory.go
+++ b/internal/candidate_runner/factory.go
@@ -38,6 +38,7 @@ func (factory *CandidateRunnerFactory) build() *candidateRunner {
 		runEvery:                  factory.conf.rerunEvery,
 		eventRecorder:             factory.conf.eventRecorder,
 		maxSimultaneousCandidates: factory.conf.maxSimultaneousCandidates,
+		maxSimultaneousDrained:    factory.conf.maxSimultaneousDrained,
 		drainSimulator:            factory.conf.drainSimulator,
 		dryRun:                    factory.conf.dryRun,
 		nodeSorters:               factory.conf.nodeSorters,

--- a/internal/candidate_runner/info.go
+++ b/internal/candidate_runner/info.go
@@ -20,7 +20,8 @@ type DataInfo struct {
 	// Candidate Run
 	NodeCount                        int           // initial node count in the group
 	FilteredOutCount                 int           // How many nodes were filtered out
-	Slots                            int           // How many slots are available in total
+	CandidateSlots                   int           // How many candidate slots are available in total
+	DrainedSlots                     int           // How many already drained slots are available in total
 	ProcessingDuration               time.Duration // How long does the loop took to run entirely
 	LastRunTime                      time.Time     // When was the runner loop launched the last time
 	LastNodeIteratorTime             time.Time     // When did the loop had to node to iterate on AFTER the filtering part
@@ -29,7 +30,8 @@ type DataInfo struct {
 	LastSimulationRejections         []string      // Nodes that were rejected by the drain simulation during the candidate evaluation
 	LastConditionRateLimitRejections []string      // Nodes that were rejected because of missing condition rate limiting budget
 	LastRunRateLimited               bool          // Indicates if the last run was stopped because of client side rate limiting
-	CurrentCandidates                []string      // Nodes that are currently in candidate state always: len(CurrentCandidtaes) <= Slots
+	CurrentCandidates                []string      // Nodes that are currently in candidate state always: len(CurrentCandidates) <= CandidateSlots
+	CurrentDrained                   []string      // Nodes that are currently in drained state always: len(CurrentDrained) <= DrainedSlots
 
 	// private filed that should not go through the serialization
 	lastNodeIterator scheduler.ItemProvider[*v1.Node] // Pointer to the last SortingTreeRepresentation as it was left by the last run.

--- a/internal/candidate_runner/runner_test.go
+++ b/internal/candidate_runner/runner_test.go
@@ -1,14 +1,15 @@
 package candidate_runner
 
 import (
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/utils/clock"
 	testing2 "k8s.io/utils/clock/testing"
-	"reflect"
-	"testing"
-	"time"
 )
 
 var clockInTest clock.Clock
@@ -42,44 +43,78 @@ func Test_candidateRunner_checkAlreadyCandidates(t *testing.T) {
 	taint = k8sclient.CreateNLATaint(k8sclient.TaintDrained, clockInTest.Now())
 	n3Drained, _, _ = taints.AddOrUpdateTaint(n3Drained, taint)
 
+	n4Drained := &corev1.Node{}
+	taint = k8sclient.CreateNLATaint(k8sclient.TaintDrained, clockInTest.Now())
+	n4Drained, _, _ = taints.AddOrUpdateTaint(n4Drained, taint)
+
 	tests := []struct {
 		name                      string
 		nodes                     []*corev1.Node
 		maxCandidate              int
+		maxDrained                int
 		wantRemainingNodes        []*corev1.Node
 		wantAlreadyCandidateNodes []*corev1.Node
+		wantAlreadyDrainedNodes   []*corev1.Node
 		wantMaxCandidateReached   bool
+		wantMaxDrainedReached     bool
 	}{
 		{
 			name:                      "check taints no max",
 			nodes:                     []*corev1.Node{n0, n1Candidate, n2Draining, n10, n100, n3Drained},
 			wantRemainingNodes:        []*corev1.Node{n0, n10, n100},
-			wantAlreadyCandidateNodes: []*corev1.Node{n1Candidate, n2Draining, n3Drained},
+			wantAlreadyCandidateNodes: []*corev1.Node{n1Candidate, n2Draining},
 			wantMaxCandidateReached:   false,
 		},
 		{
-			name:                      "check taints max=2",
+			name:                      "check taints maxCandidate=2",
 			maxCandidate:              2,
 			nodes:                     []*corev1.Node{n0, n1Candidate, n2Draining, n10, n100, n3Drained},
 			wantRemainingNodes:        nil,
 			wantAlreadyCandidateNodes: []*corev1.Node{n1Candidate, n2Draining},
 			wantMaxCandidateReached:   true,
 		},
+		{
+			name:                      "maxCandidate=1, maxDrained=2, maxDrained reached",
+			maxCandidate:              1,
+			maxDrained:                2,
+			nodes:                     []*corev1.Node{n0, n3Drained, n4Drained, n10, n100},
+			wantRemainingNodes:        nil,
+			wantAlreadyCandidateNodes: []*corev1.Node{},
+			wantMaxCandidateReached:   false,
+			wantMaxDrainedReached:     true,
+		},
+		{
+			name:                      "maxCandidate=1, maxDrained=2, maxDrained not reached",
+			maxCandidate:              1,
+			maxDrained:                2,
+			nodes:                     []*corev1.Node{n0, n3Drained, n10, n100},
+			wantRemainingNodes:        []*corev1.Node{n0, n10, n100},
+			wantAlreadyCandidateNodes: []*corev1.Node{},
+			wantMaxCandidateReached:   false,
+			wantMaxDrainedReached:     false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runner := &candidateRunner{
 				maxSimultaneousCandidates: tt.maxCandidate,
+				maxSimultaneousDrained:    tt.maxDrained,
 			}
-			gotRemainingNodes, gotAlreadyCandidateNodes, gotMaxCandidateReached := runner.checkAlreadyCandidates(tt.nodes)
+			gotRemainingNodes, gotAlreadyCandidateNodes, gotAlreadyDrainedNodes, gotMaxCandidateReached, gotMaxDrainedReached := runner.checkAlreadyCandidates(tt.nodes)
 			if !reflect.DeepEqual(gotRemainingNodes, tt.wantRemainingNodes) {
 				t.Errorf("checkAlreadyCandidates() gotRemainingNodes = %v, want %v", gotRemainingNodes, tt.wantRemainingNodes)
 			}
 			if !reflect.DeepEqual(gotAlreadyCandidateNodes, tt.wantAlreadyCandidateNodes) {
 				t.Errorf("checkAlreadyCandidates() gotAlreadyCandidateNodes = %v, want %v", gotAlreadyCandidateNodes, tt.wantAlreadyCandidateNodes)
 			}
+			if !reflect.DeepEqual(gotAlreadyCandidateNodes, tt.wantAlreadyCandidateNodes) {
+				t.Errorf("checkAlreadyCandidates() gotAlreadyDrainedNodes = %v, want %v", gotAlreadyDrainedNodes, tt.wantAlreadyDrainedNodes)
+			}
 			if gotMaxCandidateReached != tt.wantMaxCandidateReached {
 				t.Errorf("checkAlreadyCandidates() gotMaxCandidateReached = %v, want %v", gotMaxCandidateReached, tt.wantMaxCandidateReached)
+			}
+			if gotMaxDrainedReached != tt.wantMaxDrainedReached {
+				t.Errorf("checkAlreadyCandidates() gotMaxDrainedReached = %v, want %v", gotMaxDrainedReached, tt.wantMaxDrainedReached)
 			}
 		})
 	}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -273,7 +273,7 @@ func (h *CLICommands) cmdGroupList() error {
 	}
 
 	table := table.NewTable([]string{
-		"Group", "Nodes", "Slot", "Filtered", "Simulation failed", "Cond. Rate Limited", "Warn", "Last Run Aborted", "Last Candidate Run", "Candidate Duration", "Last Candidate(s)", "Last Candidate(s) At", "Last Candidates Sort", "Drain Duration", "Drain Buffer",
+		"Group", "Nodes", "CandidateSlots", "DrainedSlots", "Filtered", "Simulation failed", "Cond. Rate Limited", "Warn", "Last Run Aborted", "Last Candidate Run", "Candidate Duration", "Last Candidate(s)", "Last Candidate(s) At", "Last Candidates Sort", "Drain Duration", "Drain Buffer",
 	},
 		func(obj interface{}) []string {
 			item := obj.(groups.RunnerInfo)
@@ -289,7 +289,7 @@ func (h *CLICommands) cmdGroupList() error {
 			warn := ""
 			if candidateDataInfo.NodeCount > 0 {
 				// Show warning if there are free slots available and we have potential candidates that fail on the way to get the taint
-				if len(candidateDataInfo.CurrentCandidates) < candidateDataInfo.Slots && candidateDataInfo.NodeCount > candidateDataInfo.FilteredOutCount {
+				if len(candidateDataInfo.CurrentCandidates) < candidateDataInfo.CandidateSlots && candidateDataInfo.NodeCount > candidateDataInfo.FilteredOutCount {
 					warn = "*"
 				}
 
@@ -300,11 +300,13 @@ func (h *CLICommands) cmdGroupList() error {
 				lastRunAborted = "*"
 			}
 
-			remainingSlots := candidateDataInfo.Slots - len(candidateDataInfo.CurrentCandidates)
+			remainingCandidateSlots := candidateDataInfo.CandidateSlots - len(candidateDataInfo.CurrentCandidates)
+			remainingDrainedSlots := candidateDataInfo.DrainedSlots - len(candidateDataInfo.CurrentDrained)
 			return []string{
 				string(item.Key),
 				fmt.Sprintf("%v", candidateDataInfo.NodeCount),
-				fmt.Sprintf("%d/%d", remainingSlots, candidateDataInfo.Slots),
+				fmt.Sprintf("%d/%d", remainingCandidateSlots, candidateDataInfo.CandidateSlots),
+				fmt.Sprintf("%d/%d", remainingDrainedSlots, candidateDataInfo.DrainedSlots),
 				fmt.Sprintf("%v", candidateDataInfo.FilteredOutCount),
 				fmt.Sprintf("%v", candidateDataInfo.LastSimulationRejections),
 				fmt.Sprintf("%d", len(candidateDataInfo.LastConditionRateLimitRejections)),

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -56,19 +56,33 @@ var (
 	}, candidateRunnerTags)
 	candidateRunnerFilteredOutNodesCleaner gmetrics.GaugeCleaner
 
-	candidateRunnerTotalSlots = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	candidateRunnerTotalCandidateSlots = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: metrics.CandidateRunnerSubsystem,
 		Name:      "total_slots",
 		Help:      "Total amount of available drain candidate slots",
 	}, candidateRunnerTags)
-	candidateRunnerTotalSlotsCleaner gmetrics.GaugeCleaner
+	candidateRunnerTotalCandidateSlotsCleaner gmetrics.GaugeCleaner
 
-	candidateRunnerRemainingSlots = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	candidateRunnerTotalDrainedSlots = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metrics.CandidateRunnerSubsystem,
+		Name:      "total_drained_slots",
+		Help:      "Total amount of available already drained slots",
+	}, candidateRunnerTags)
+	candidateRunnerTotalDrainedSlotsCleaner gmetrics.GaugeCleaner
+
+	candidateRunnerRemainingCandidateSlots = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: metrics.CandidateRunnerSubsystem,
 		Name:      "remaining_slots",
 		Help:      "Current remaining drain candidate slots",
 	}, candidateRunnerTags)
-	candidateRunnerRemainingSlotsCleaner gmetrics.GaugeCleaner
+	candidateRunnerRemainingCandidateSlotsCleaner gmetrics.GaugeCleaner
+
+	candidateRunnerRemainingDrainedSlots = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metrics.CandidateRunnerSubsystem,
+		Name:      "remaining_drained_slots",
+		Help:      "Current remaining already drained slots",
+	}, candidateRunnerTags)
+	candidateRunnerRemainingDrainedSlotsCleaner gmetrics.GaugeCleaner
 
 	candidateRunnerSimulationRejections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: metrics.CandidateRunnerSubsystem,
@@ -105,8 +119,10 @@ func initGaugeCleaner(cleanupPeriod time.Duration) {
 	// Candidate Runner Subsystem
 	candidateRunnerTotalNodesCleaner = gmetrics.NewGaugeCleaner(candidateRunnerTotalNodes, candidateRunnerTags, cleanupPeriod)
 	candidateRunnerFilteredOutNodesCleaner = gmetrics.NewGaugeCleaner(candidateRunnerFilteredOutNodes, candidateRunnerTags, cleanupPeriod)
-	candidateRunnerTotalSlotsCleaner = gmetrics.NewGaugeCleaner(candidateRunnerTotalSlots, candidateRunnerTags, cleanupPeriod)
-	candidateRunnerRemainingSlotsCleaner = gmetrics.NewGaugeCleaner(candidateRunnerRemainingSlots, candidateRunnerTags, cleanupPeriod)
+	candidateRunnerTotalCandidateSlotsCleaner = gmetrics.NewGaugeCleaner(candidateRunnerTotalCandidateSlots, candidateRunnerTags, cleanupPeriod)
+	candidateRunnerTotalDrainedSlotsCleaner = gmetrics.NewGaugeCleaner(candidateRunnerTotalDrainedSlots, candidateRunnerTags, cleanupPeriod)
+	candidateRunnerRemainingCandidateSlotsCleaner = gmetrics.NewGaugeCleaner(candidateRunnerRemainingCandidateSlots, candidateRunnerTags, cleanupPeriod)
+	candidateRunnerRemainingDrainedSlotsCleaner = gmetrics.NewGaugeCleaner(candidateRunnerRemainingDrainedSlots, candidateRunnerTags, cleanupPeriod)
 	candidateRunnerSimulationRejectionsCleaner = gmetrics.NewGaugeCleaner(candidateRunnerSimulationRejections, candidateRunnerTags, cleanupPeriod)
 	candidateRunnerConditionRateLimitedCleaner = gmetrics.NewGaugeCleaner(candidateRunnerConditionRateLimited, candidateRunnerTags, cleanupPeriod)
 	candidateRunnerRunRateLimitedCleaner = gmetrics.NewGaugeCleaner(candidateRunnerRunRateLimited, candidateRunnerTags, cleanupPeriod)
@@ -125,6 +141,6 @@ func RegisterNewMetrics(registry *prometheus.Registry, cleanupPeriod time.Durati
 		registry.MustRegister(groupRunnerLoopDuration)
 
 		// Candidate Runner Subsystem
-		registry.MustRegister(candidateRunnerTotalNodes, candidateRunnerFilteredOutNodes, candidateRunnerTotalSlots, candidateRunnerRemainingSlots, candidateRunnerSimulationRejections, candidateRunnerConditionRateLimited)
+		registry.MustRegister(candidateRunnerTotalNodes, candidateRunnerFilteredOutNodes, candidateRunnerTotalCandidateSlots, candidateRunnerTotalDrainedSlots, candidateRunnerRemainingCandidateSlots, candidateRunnerRemainingDrainedSlots, candidateRunnerSimulationRejections, candidateRunnerConditionRateLimited)
 	})
 }

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -384,7 +384,9 @@ func (s *DrainoConfigurationObserverImpl) ProduceGroupRunnerMetrics() {
 		candidateRunnerTags := []string{string(group)}
 		candidateRunnerTotalNodesCleaner.SetAndPlanCleanup(float64(candidateDataInfo.NodeCount), candidateRunnerTags, false, cleanupPeriod, false)
 		candidateRunnerFilteredOutNodesCleaner.SetAndPlanCleanup(float64(candidateDataInfo.FilteredOutCount), candidateRunnerTags, false, cleanupPeriod, false)
-		candidateRunnerTotalSlotsCleaner.SetAndPlanCleanup(float64(candidateDataInfo.Slots), candidateRunnerTags, false, cleanupPeriod, false)
+		candidateRunnerTotalCandidateSlotsCleaner.SetAndPlanCleanup(float64(candidateDataInfo.CandidateSlots), candidateRunnerTags, false, cleanupPeriod, false)
+		candidateRunnerTotalDrainedSlotsCleaner.SetAndPlanCleanup(float64(candidateDataInfo.DrainedSlots), candidateRunnerTags, false, cleanupPeriod, false)
+
 		candidateRunnerSimulationRejectionsCleaner.SetAndPlanCleanup(float64(len(candidateDataInfo.LastSimulationRejections)), candidateRunnerTags, false, cleanupPeriod, false)
 		candidateRunnerConditionRateLimitedCleaner.SetAndPlanCleanup(float64(len(candidateDataInfo.LastConditionRateLimitRejections)), candidateRunnerTags, false, cleanupPeriod, false)
 
@@ -394,8 +396,11 @@ func (s *DrainoConfigurationObserverImpl) ProduceGroupRunnerMetrics() {
 		}
 		candidateRunnerRunRateLimitedCleaner.SetAndPlanCleanup(wasRateLimited, candidateRunnerTags, false, cleanupPeriod, false)
 
-		remainingSlots := candidateDataInfo.Slots - len(candidateDataInfo.CurrentCandidates)
-		candidateRunnerRemainingSlotsCleaner.SetAndPlanCleanup(float64(remainingSlots), candidateRunnerTags, false, cleanupPeriod, false)
+		remainingCandidateSlots := candidateDataInfo.CandidateSlots - len(candidateDataInfo.CurrentCandidates)
+		candidateRunnerRemainingCandidateSlotsCleaner.SetAndPlanCleanup(float64(remainingCandidateSlots), candidateRunnerTags, false, cleanupPeriod, false)
+
+		remainingDrainedSlots := candidateDataInfo.DrainedSlots - len(candidateDataInfo.CurrentDrained)
+		candidateRunnerRemainingDrainedSlotsCleaner.SetAndPlanCleanup(float64(remainingDrainedSlots), candidateRunnerTags, false, cleanupPeriod, false)
 	}
 }
 


### PR DESCRIPTION
Currently there is only 1 available slot per drain group for a node that is in either candidate, draining, or drained state. This slows down rotations since we must wait until the drained node is cleaned up by cluster autoscaler, which could take a very long time if there are other scaleups occurring in the cluster.

So by having a different number of slots for nodes that are already drained, nodes in a drain group will still be able to be drained, while having some nodes in a drained state. Cluster autoscaler can then downscale these drained nodes in bulk