### PR TITLE
add tag service on some metrics

### DIFF
--- a/internal/candidate_runner/sorters/node_annotations.go
+++ b/internal/candidate_runner/sorters/node_annotations.go
@@ -6,9 +6,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/planetlabs/draino/internal/kubernetes"
 	"github.com/planetlabs/draino/internal/kubernetes/index"
-	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -51,7 +52,7 @@ func NewAnnotationPrioritizer(store kubernetes.RuntimeObjectStore, indexer *inde
 }
 
 func getHighestPrioFromNode(ctx context.Context, store kubernetes.RuntimeObjectStore, indexer *index.Indexer, eventRecorder kubernetes.EventRecorder, node *v1.Node) (int, bool, error) {
-	searchRes, err := kubernetes.SearchAnnotationFromNodeAndThenPodOrController(ctx, indexer, store, convertPriority, AnnotationDrainPriorityPKey, node, false, false)
+	searchRes, err := kubernetes.SearchAnnotationFromNodeAndThenPodOrController(ctx, indexer, nil, store, convertPriority, AnnotationDrainPriorityPKey, node, false, false)
 	if err != nil {
 		return 0, false, err
 	}

--- a/internal/drain_buffer/drain_buffer.go
+++ b/internal/drain_buffer/drain_buffer.go
@@ -76,7 +76,7 @@ const (
 
 // GetDrainBufferConfigurationDetails retrieve all the drain configuration details
 func (buffer *drainBufferImpl) GetDrainBufferConfigurationDetails(ctx context.Context, node *v1.Node) (*kubernetes.MetadataSearch[time.Duration], error) {
-	return kubernetes.SearchAnnotationFromNodeAndThenPodOrController(ctx, buffer.podIndexer, buffer.store, time.ParseDuration, CustomDrainBufferAnnotation, node, false, false)
+	return kubernetes.SearchAnnotationFromNodeAndThenPodOrController(ctx, buffer.podIndexer, nil, buffer.store, time.ParseDuration, CustomDrainBufferAnnotation, node, false, false)
 }
 
 // GetDrainBufferConfiguration does a best effort to find a valid configuration and always return a value. The error can be non nil if something went wrong during the processing, still the value can be used. Worst case you get the default value.

--- a/internal/drain_runner/metrics.go
+++ b/internal/drain_runner/metrics.go
@@ -19,11 +19,11 @@ var (
 		DrainedNodes: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "draino_drained_nodes_total",
 			Help: "Number of nodes drained.",
-		}, []string{kubernetes.TagResult.Name(), kubernetes.TagFailureCause.Name(), kubernetes.TagConditions.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name()}),
+		}, []string{kubernetes.TagResult.Name(), kubernetes.TagFailureCause.Name(), kubernetes.TagConditions.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name(), kubernetes.TagService.Name()}),
 		PreProcessorFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "pre_processor_failures",
 			Help: "Number of failures per nodegroup",
-		}, []string{metrics.TagPreProcessor, metrics.TagReason, metrics.TagNodegroupName, metrics.TagNodegroupNamespace, metrics.TagGroupKey}),
+		}, []string{metrics.TagPreProcessor, metrics.TagReason, metrics.TagNodegroupName, metrics.TagNodegroupNamespace, metrics.TagGroupKey, metrics.TagService}),
 	}
 	registerOnce sync.Once
 )
@@ -50,14 +50,14 @@ func CounterDrainedNodes(node *core.Node, result DrainNodesResult, conditions []
 	conditionTypes := append(kubernetes.GetConditionsTypes(conditions), metrics.TagConditionAnyValue)
 
 	for _, c := range conditionTypes {
-		tags := []string{string(result), string(failureReason), c, values.NgName, kubernetes.GetNodeGroupNamePrefix(values.NgName), values.NgNamespace, values.Team}
+		tags := []string{string(result), string(failureReason), c, values.NgName, kubernetes.GetNodeGroupNamePrefix(values.NgName), values.NgNamespace, values.Team, values.Service}
 		Metrics.DrainedNodes.WithLabelValues(tags...).Add(1)
 	}
 }
 
 func CounterPreProcessorFailures(node *core.Node, preProcName, reason, drainGroup string) {
 	values := kubernetes.GetNodeTagsValues(node)
-	Metrics.PreProcessorFailures.WithLabelValues(preProcName, reason, values.NgName, values.NgNamespace, drainGroup).Add(1)
+	Metrics.PreProcessorFailures.WithLabelValues(preProcName, reason, values.NgName, values.NgNamespace, drainGroup, values.Service).Add(1)
 }
 
 const (

--- a/internal/drain_runner/pre_processor/pre_activities.go
+++ b/internal/drain_runner/pre_processor/pre_activities.go
@@ -148,11 +148,11 @@ type preActivity struct {
 // getActivities will search for all pre activity annotations in the whole chain (node -> pod -> controller).
 // Furthermore, it's going to evaluate the timeout annotation for the same activity
 func (pre *PreActivitiesPreProcessor) getActivities(ctx context.Context, node *corev1.Node) (map[string]*preActivity, error) {
-	activitySearch, err := kubernetes.NewSearch(ctx, pre.podIndexer, pre.store, preActivityStateConverter, node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
+	activitySearch, err := kubernetes.NewSearch(ctx, pre.podIndexer, nil, pre.store, preActivityStateConverter, node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
 	if err != nil {
 		return nil, err
 	}
-	activityTimeoutSearch, err := kubernetes.NewSearch(ctx, pre.podIndexer, pre.store, time.ParseDuration, node, PreActivityTimeoutAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
+	activityTimeoutSearch, err := kubernetes.NewSearch(ctx, pre.podIndexer, nil, pre.store, time.ParseDuration, node, PreActivityTimeoutAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/drain_runner/pre_processor/pre_activities_test.go
+++ b/internal/drain_runner/pre_processor/pre_activities_test.go
@@ -6,9 +6,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/planetlabs/draino/internal/kubernetes"
-	"github.com/planetlabs/draino/internal/kubernetes/index"
-	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +14,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
+
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
 )
 
 func TestPreActivitiesPreProcessor(t *testing.T) {
@@ -368,7 +369,7 @@ func TestPreActivitiesPreProcessor_Reset(t *testing.T) {
 			var node corev1.Node
 			err = wrapper.GetManagerClient().Get(ctx, types.NamespacedName{Name: tt.Node.Name}, &node)
 			assert.NoError(t, err, "Failed to refresh node")
-			result, err := kubernetes.NewSearch(ctx, idx, store, preActivityStateConverter, &node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
+			result, err := kubernetes.NewSearch(ctx, idx, nil, store, preActivityStateConverter, &node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
 			for _, item := range result.Results() {
 				assert.Equal(t, PreActivityAnnotationNotStarted, item.Value, "Did not properly reset pre-activity for: %v", item.Source)
 			}

--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -1,6 +1,12 @@
 package kubernetes
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+)
 
 type GlobalConfig struct {
 	// Main context
@@ -14,4 +20,115 @@ type GlobalConfig struct {
 
 	// SuppliedConditions List of conditions that the controller should react on
 	SuppliedConditions []SuppliedCondition
+}
+
+type FilterOptions struct {
+	DoNotEvictPodControlledBy              []string
+	EvictLocalStoragePods                  bool
+	ProtectedPodAnnotations                []string
+	DoNotCandidatePodControlledBy          []string
+	CandidateLocalStoragePods              bool
+	ExcludeStatefulSetOnNodeWithoutStorage bool
+	CandidateProtectedPodAnnotations       []string
+	OptInPodAnnotations                    []string
+	ShortLivedPodAnnotations               []string
+	NodeLabels                             []string
+	NodeLabelsExpr                         string
+}
+
+type FiltersDefinitions struct {
+	// CandidatePodFilter, Should the pod block the node for being candidate ?
+	CandidatePodFilter PodFilterFunc
+	// DrainPodFilter, Should the pod be drained ?
+	DrainPodFilter PodFilterFunc
+
+	// NodeLabelFilter, Is the node eligible (label checks only) ?
+	NodeLabelFilter NodeLabelFilterFunc
+}
+
+func GenerateFilters(cs *kubernetes.Clientset, store RuntimeObjectStore, log *zap.Logger, options FilterOptions) (FiltersDefinitions, error) {
+	pf := []PodFilterFunc{MirrorPodFilter}
+	if !options.EvictLocalStoragePods {
+		pf = append(pf, LocalStoragePodFilter)
+	}
+
+	apiResources, err := GetAPIResourcesForGVK(cs, options.DoNotEvictPodControlledBy, log)
+	if err != nil {
+		return FiltersDefinitions{}, fmt.Errorf("failed to get resources for controlby filtering for eviction: %v", err)
+	}
+	if len(apiResources) > 0 {
+		for _, apiResource := range apiResources {
+			if apiResource == nil {
+				log.Info("Filtering pod that are uncontrolled for eviction")
+			} else {
+				log.Info("Filtering pods controlled by apiresource for eviction", zap.Any("apiresource", *apiResource))
+			}
+		}
+		pf = append(pf, NewPodControlledByFilter(apiResources))
+	}
+	systemKnownAnnotations := []string{
+		// https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
+		"cluster-autoscaler.kubernetes.io/safe-to-evict=false",
+	}
+	pf = append(pf, UnprotectedPodFilter(store, false, append(systemKnownAnnotations, options.ProtectedPodAnnotations...)...))
+
+	// Candidate Filtering
+	podFilterCandidate := []PodFilterFunc{}
+	if !options.CandidateLocalStoragePods {
+		podFilterCandidate = append(podFilterCandidate, LocalStoragePodFilter)
+	}
+	apiResourcesPodControllerBy, err := GetAPIResourcesForGVK(cs, options.DoNotCandidatePodControlledBy, log)
+	if err != nil {
+		return FiltersDefinitions{}, fmt.Errorf("failed to get resources for 'controlledBy' filtering for being candidate: %v", err)
+	}
+	if len(apiResourcesPodControllerBy) > 0 {
+		for _, apiResource := range apiResourcesPodControllerBy {
+			if apiResource == nil {
+				log.Info("Filtering pods that are uncontrolled for being candidate")
+			} else {
+				log.Info("Filtering pods controlled by apiresource for being candidate", zap.Any("apiresource", *apiResource))
+			}
+		}
+		podFilterCandidate = append(podFilterCandidate, NewPodControlledByFilter(apiResourcesPodControllerBy))
+	}
+	podFilterCandidate = append(podFilterCandidate, UnprotectedPodFilter(store, true, options.CandidateProtectedPodAnnotations...))
+
+	// To maintain compatibility with draino v1 version we have to exclude pods from STS running on node without local-storage
+	if options.ExcludeStatefulSetOnNodeWithoutStorage {
+		podFilterCandidate = append(podFilterCandidate, NewPodFiltersNoStatefulSetOnNodeWithoutDisk(store))
+	}
+
+	consolidatedOptInAnnotations := append(options.OptInPodAnnotations, options.ShortLivedPodAnnotations...)
+	drainerSkipPodFilter := NewPodFiltersIgnoreCompletedPods(
+		NewPodFiltersIgnoreShortLivedPods(
+			NewPodFiltersWithOptInFirst(PodOrControllerHasAnyOfTheAnnotations(store, consolidatedOptInAnnotations...), NewPodFilters(pf...)),
+			store, options.ShortLivedPodAnnotations...))
+
+	podFilteringFunc := NewPodFiltersIgnoreCompletedPods(
+		NewPodFiltersWithOptInFirst(
+			PodOrControllerHasAnyOfTheAnnotations(store, consolidatedOptInAnnotations...), NewPodFilters(podFilterCandidate...)))
+
+	// Node filtering
+	if len(options.NodeLabels) > 0 {
+		log.Info("node labels", zap.Any("labels", options.NodeLabels))
+		if options.NodeLabelsExpr != "" {
+			return FiltersDefinitions{}, fmt.Errorf("nodeLabels and NodeLabelsExpr cannot both be set")
+		}
+		if ptrStr, err := ConvertLabelsToFilterExpr(options.NodeLabels); err != nil {
+			return FiltersDefinitions{}, err
+		} else {
+			options.NodeLabelsExpr = *ptrStr
+		}
+	}
+	log.Debug("label expression", zap.Any("expr", options.NodeLabelsExpr))
+	nodeLabelFilterFunc, err := NewNodeLabelFilter(options.NodeLabelsExpr, log)
+	if err != nil {
+		return FiltersDefinitions{}, fmt.Errorf("Failed to parse node label expression: %v", err)
+	}
+
+	return FiltersDefinitions{
+		CandidatePodFilter: podFilteringFunc,
+		DrainPodFilter:     drainerSkipPodFilter,
+		NodeLabelFilter:    nodeLabelFilterFunc,
+	}, nil
 }

--- a/internal/kubernetes/metadata_search_test.go
+++ b/internal/kubernetes/metadata_search_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/planetlabs/draino/internal/kubernetes/index"
-	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/apps/v1"
@@ -17,6 +15,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
 )
 
 func TestSearcAnnotationFromNodeAndThenPodOrController(t *testing.T) {
@@ -203,7 +204,7 @@ func TestSearcAnnotationFromNodeAndThenPodOrController(t *testing.T) {
 				t.Fatalf("can't create fakeIndexer: %#v", err)
 			}
 
-			got, err := SearchAnnotationFromNodeAndThenPodOrController(context.Background(), fakeIndexer, store, func(s string) (string, error) { return s, nil }, testKey, tt.node, true, true)
+			got, err := SearchAnnotationFromNodeAndThenPodOrController(context.Background(), fakeIndexer, nil, store, func(s string) (string, error) { return s, nil }, testKey, tt.node, true, true)
 			if tt.wantErr != (err != nil) {
 				fmt.Printf("%sGetAnnotationFromNodeAndThenPodOrController() ERR: %#v", tt.name, err)
 				t.Failed()
@@ -561,7 +562,7 @@ func TestMetadataSearch_WithAnnotationPrefix(t *testing.T) {
 				t.Fatalf("can't create fakeIndexer: %#v", err)
 			}
 
-			got, err := NewSearch(context.Background(), fakeIndexer, store, func(s string) (string, error) { return s, nil }, tt.Node, tt.KeyPrefix, false, false, GetPrefixedAnnotation)
+			got, err := NewSearch(context.Background(), fakeIndexer, nil, store, func(s string) (string, error) { return s, nil }, tt.Node, tt.KeyPrefix, false, false, GetPrefixedAnnotation)
 			if tt.WantErr != (err != nil) {
 				fmt.Printf("%sGetAnnotationFromNodeAndThenPodOrController() ERR: %#v", tt.Name, err)
 				t.Failed()

--- a/internal/kubernetes/metrics.go
+++ b/internal/kubernetes/metrics.go
@@ -15,6 +15,7 @@ var (
 	TagNodeName, _                        = tag.NewKey("node_name")
 	TagConditions, _                      = tag.NewKey("conditions")
 	TagTeam, _                            = tag.NewKey("team")
+	TagService, _                         = tag.NewKey("service")
 	TagNodegroupName, _                   = tag.NewKey("nodegroup_name")
 	TagNodegroupNamePrefix, _             = tag.NewKey("nodegroup_name_prefix")
 	TagNodegroupNamespace, _              = tag.NewKey("nodegroup_namespace")

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -211,7 +211,7 @@ func GetAPIResourcesForGVK(discoveryInterface discovery.DiscoveryInterface, gvks
 }
 
 type NodeTagsValues struct {
-	Team, NgName, NgNamespace string
+	Team, NgName, NgNamespace, Service string
 }
 
 func GetNodeTagsValues(node *core.Node) NodeTagsValues {
@@ -219,10 +219,16 @@ func GetNodeTagsValues(node *core.Node) NodeTagsValues {
 	if team == "" {
 		team = node.Labels["team"]
 	}
+	service := node.Labels["service"]
+	if service == "" {
+		service = node.Annotations["service"]
+	}
+
 	return NodeTagsValues{
 		Team:        team,
 		NgName:      node.Labels[LabelKeyNodeGroupName],
 		NgNamespace: node.Labels[LabelKeyNodeGroupNamespace],
+		Service:     service,
 	}
 }
 
@@ -232,7 +238,7 @@ func GetNodeGroupNamePrefix(ngName string) string {
 
 func nodeTags(ctx context.Context, node *core.Node) (context.Context, error) {
 	values := GetNodeTagsValues(node)
-	return tag.New(ctx, tag.Upsert(TagNodegroupNamespace, values.NgNamespace), tag.Upsert(TagNodegroupName, values.NgName), tag.Upsert(TagNodegroupNamePrefix, GetNodeGroupNamePrefix(values.NgName)), tag.Upsert(TagTeam, values.Team))
+	return tag.New(ctx, tag.Upsert(TagNodegroupNamespace, values.NgNamespace), tag.Upsert(TagNodegroupName, values.NgName), tag.Upsert(TagNodegroupNamePrefix, GetNodeGroupNamePrefix(values.NgName)), tag.Upsert(TagTeam, values.Team), tag.Upsert(TagService, values.Service))
 }
 
 func StatRecordForNode(ctx context.Context, node *core.Node, m stats.Measurement) {

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -22,4 +22,5 @@ const (
 	TagFilter             = "filter"
 	TagPreProcessor       = "pre_processor"
 	TagTeam               = "team"
+	TagService            = "service"
 )

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -169,8 +169,7 @@ func TestScopeObserverImpl_GetLabelUpdate(t *testing.T) {
 				kclient:            kclient,
 				runtimeObjectStore: runtimeObjectStore,
 				globalConfig:       kubernetes.GlobalConfig{ConfigName: tt.configName},
-				nodeFilterFunc:     tt.nodeFilterFunc,
-				podFilterFunc:      tt.podFilterFunc,
+				filtersDefinitions: kubernetes.FiltersDefinitions{NodeLabelFilter: tt.nodeFilterFunc, CandidatePodFilter: tt.podFilterFunc},
 				logger:             zap.NewNop(),
 			}
 
@@ -356,9 +355,8 @@ func TestScopeObserverImpl_updateNodeAnnotationsAndLabels(t *testing.T) {
 					ConfigName:         tt.configName,
 					SuppliedConditions: suppliedConditions,
 				},
-				nodeFilterFunc: tt.nodeFilterFunc,
-				podFilterFunc:  kubernetes.NewPodFilters(),
-				logger:         zap.NewNop(),
+				filtersDefinitions: kubernetes.FiltersDefinitions{NodeLabelFilter: tt.nodeFilterFunc, CandidatePodFilter: kubernetes.NewPodFilters()},
+				logger:             zap.NewNop(),
 			}
 			err = s.patchNodeLabels(tt.nodeName)
 			if err == nil && tt.wantErr {


### PR DESCRIPTION
Add tag `service` to some of the metrics.
The tag `service` will allow us to connect to service catalog for some analysis (who is associated with the service) but also will ease future integration with SDP (push some NLA relevant information to SDP).