### PR TITLE
Eviction++ dry-run

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -268,9 +268,9 @@ func main() {
 			return err
 		}
 
-		simulationPodFilter := kubernetes.NewPodFilters(filtersDef.DrainPodFilter, kubernetes.PodOrControllerHasNoneOfTheAnnotations(store, kubernetes.EvictionAPIURLAnnotationKey))
+		simulationPodFilter := kubernetes.NewPodFilters(filtersDef.DrainPodFilter)
 		simulationRateLimiter := limit.NewRateLimiter(clock.RealClock{}, cfg.KubeClientConfig.QPS*options.simulationRateLimitingRatio, int(float32(cfg.KubeClientConfig.Burst)*options.simulationRateLimitingRatio))
-		simulator := drain.NewDrainSimulator(context.Background(), mgr.GetClient(), indexer, simulationPodFilter, eventRecorder, simulationRateLimiter, logger)
+		simulator := drain.NewDrainSimulator(context.Background(), mgr.GetClient(), indexer, simulationPodFilter, eventRecorder, simulationRateLimiter, logger, store, globalConfig)
 		pdbAnalyser := analyser.NewPDBAnalyser(ctx, mgr.GetLogger(), indexer, clock.RealClock{}, options.podWarmupDelayExtension)
 		sorters := candidate_runner.NodeSorters{
 			sorters.NewAnnotationPrioritizer(store, indexer, eventRecorder, logger),

--- a/internal/kubernetes/drain/simulator.go
+++ b/internal/kubernetes/drain/simulator.go
@@ -251,7 +251,7 @@ func (sim *drainSimulatorImpl) simulateAPIEviction(ctx context.Context, pod *cor
 func (sim *drainSimulatorImpl) operatorAPIDryRunEnabled(pod *corev1.Pod) bool {
 	if sim.usesOperatorAPI(pod) {
 		_, ok := kubernetes.GetAnnotationFromPodOrController(kubernetes.EvictionAPIDryRunSupportedAnnotationKey, pod, sim.runtimeObjectStore)
-		return !ok
+		return ok
 	}
 	return true
 }

--- a/internal/kubernetes/drain/simulator_test.go
+++ b/internal/kubernetes/drain/simulator_test.go
@@ -134,7 +134,7 @@ func TestSimulator_SimulateDrain(t *testing.T) {
 			Reason:      nil,
 			PodFilter:   noopPodFilter,
 			Node:        corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo-node"}},
-			Objects:     []runtime.Object{
+			Objects: []runtime.Object{
 				createEvictionPPPod(createPodOpts{Name: "foo-pod", Labels: testLabels, NodeName: "foo-node"}, false),
 				createPDB(createPDBOpts{Name: "foo-pdb", Labels: testLabels, Des: 2, Healthy: 1}),
 			},
@@ -145,7 +145,7 @@ func TestSimulator_SimulateDrain(t *testing.T) {
 			Reason:      []string{"Cannot drain pod 'default/foo-pod', because: Eviction dry run was not successful: Cannot evict pod 'default/foo-pod': eviction endpoint error"},
 			PodFilter:   noopPodFilter,
 			Node:        corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo-node"}},
-			Objects:     []runtime.Object{
+			Objects: []runtime.Object{
 				createEvictionPPPod(createPodOpts{Name: "foo-pod", Labels: testLabels, NodeName: "foo-node"}, true),
 				createPDB(createPDBOpts{Name: "foo-pdb", Labels: testLabels, Des: 2, Healthy: 1}),
 			},
@@ -176,10 +176,10 @@ func TestSimulator_SimulateDrain(t *testing.T) {
 }
 
 type createPodOpts struct {
-	Name             string
-	NodeName         string
-	Labels           map[string]string
-	IsNotReady       bool
+	Name       string
+	NodeName   string
+	Labels     map[string]string
+	IsNotReady bool
 }
 
 func createEvictionPPPod(opts createPodOpts, evictionPPDryRun bool) *corev1.Pod {

--- a/internal/kubernetes/drain/simulator_test.go
+++ b/internal/kubernetes/drain/simulator_test.go
@@ -128,6 +128,28 @@ func TestSimulator_SimulateDrain(t *testing.T) {
 				createPDB(createPDBOpts{Name: "foo-pdb2", Labels: testLabels, Des: 2, Healthy: 3}),
 			},
 		},
+		{
+			Name:        "Should drain eviction++ pod if not opted-in to dry-run, even if pdb missing budget",
+			IsDrainable: true,
+			Reason:      nil,
+			PodFilter:   noopPodFilter,
+			Node:        corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo-node"}},
+			Objects:     []runtime.Object{
+				createEvictionPPPod(createPodOpts{Name: "foo-pod", Labels: testLabels, NodeName: "foo-node"}, false),
+				createPDB(createPDBOpts{Name: "foo-pdb", Labels: testLabels, Des: 2, Healthy: 1}),
+			},
+		},
+		{
+			Name:        "Should not drain eviction++ pod if opted-in to dry-run if url is invalid",
+			IsDrainable: false,
+			Reason:      []string{"Cannot drain pod 'default/foo-pod', because: Eviction dry run was not successful: Cannot evict pod 'default/foo-pod': eviction endpoint error"},
+			PodFilter:   noopPodFilter,
+			Node:        corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo-node"}},
+			Objects:     []runtime.Object{
+				createEvictionPPPod(createPodOpts{Name: "foo-pod", Labels: testLabels, NodeName: "foo-node"}, true),
+				createPDB(createPDBOpts{Name: "foo-pdb", Labels: testLabels, Des: 2, Healthy: 1}),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -154,16 +176,19 @@ func TestSimulator_SimulateDrain(t *testing.T) {
 }
 
 type createPodOpts struct {
-	Name       string
-	NodeName   string
-	Labels     map[string]string
-	IsNotReady bool
+	Name             string
+	NodeName         string
+	Labels           map[string]string
+	IsNotReady       bool
 }
 
-func createEvictionPPPod(opts createPodOpts) *corev1.Pod {
+func createEvictionPPPod(opts createPodOpts, evictionPPDryRun bool) *corev1.Pod {
 	pod := createPod(opts)
 	pod.ObjectMeta.Annotations = map[string]string{
 		kubernetes.EvictionAPIURLAnnotationKey: "test-api",
+	}
+	if evictionPPDryRun {
+		pod.ObjectMeta.Annotations[kubernetes.EvictionAPIDryRunSupportedAnnotationKey] = "true"
 	}
 	return pod
 }

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -782,7 +782,6 @@ func CallOperatorAPI(ctx context.Context, logger logr.Logger, url string, pod *c
 	}
 	if dryRun {
 		// Make it a dry-run request
-		logger.Info("custom eviction dry run")
 		evictionPayload.DeleteOptions = &meta.DeleteOptions{
 			DryRun: []string{"All"},
 		}
@@ -822,7 +821,7 @@ func CallOperatorAPI(ctx context.Context, logger logr.Logger, url string, pod *c
 	}
 
 	client = &http.Client{Transport: roundTripper, Timeout: 20 * time.Second}
-	logger.Info("calling eviction++", "url", urlParsed.String())
+	logger.Info("calling eviction++", "url", urlParsed.String(), "dryRun", dryRun)
 	req, err := http.NewRequest("POST", urlParsed.String(), GetEvictionJsonPayload(evictionPayload))
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -96,8 +96,9 @@ const (
 
 	eventReasonBadValueForAnnotation = "BadValueForAnnotation"
 
-	EvictionAPIURLAnnotationKey             = "draino/eviction-api-url"
-	EvictionAPIDryRunSupportedAnnotationKey = "draino/eviction-api-dry-run-supported"
+	EvictionAPIURLAnnotationKeyDeprecated   = "draino/eviction-api-url"
+	EvictionAPIURLAnnotationKey             = "node-lifecycle.datadoghq.com/eviction-api-url"
+	EvictionAPIDryRunSupportedAnnotationKey = "node-lifecycle.datadoghq.com/eviction-api-dry-run-supported"
 )
 
 type nodeMutatorFn func(*core.Node)
@@ -691,7 +692,7 @@ func (d *APIDrainer) GetPodsToDrain(ctx context.Context, node string, podStore P
 }
 
 func (d *APIDrainer) evict(ctx context.Context, node *core.Node, pod *core.Pod, abort <-chan struct{}) error {
-	evictionAPIURL, ok := GetAnnotationFromPodOrController(EvictionAPIURLAnnotationKey, pod, d.runtimeObjectStore)
+	evictionAPIURL, ok := GetEvictionAPIURL(pod, d.runtimeObjectStore)
 	if ok {
 		return d.evictWithOperatorAPI(ctx, evictionAPIURL, node, pod, abort)
 	}
@@ -883,7 +884,7 @@ func (d *APIDrainer) evictionSequence(ctx context.Context, node *core.Node, pod 
 		case <-abort:
 			return errors.New("pod eviction aborted")
 		case <-ctx.Done():
-			_, ok := GetAnnotationFromPodOrController(EvictionAPIURLAnnotationKey, pod, d.runtimeObjectStore)
+			_, ok := GetEvictionAPIURL(pod, d.runtimeObjectStore)
 			return PodEvictionTimeoutError{isEvictionPP: ok} // this one is typed because we match it to a failure cause
 		default:
 			pvcs, err := d.getInScopePVCs(ctx, pod)

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -598,7 +598,7 @@ func TestCallOperatorAPI(t *testing.T) {
 		res.WriteHeader(http.StatusOK)
 		res.Write([]byte("body"))
 	}))
-	defer func() { okServer.Close() }()
+	defer okServer.Close()
 
 	dryRunOkServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		var evictionPayload policy.Eviction
@@ -616,13 +616,13 @@ func TestCallOperatorAPI(t *testing.T) {
 
 		res.Write([]byte("body"))
 	}))
-	defer func() { okServer.Close() }()
+	defer dryRunOkServer.Close()
 
 	internalErrorServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusInternalServerError)
 		res.Write([]byte("body"))
 	}))
-	defer func() { okServer.Close() }()
+	defer internalErrorServer.Close()
 
 	tests := []struct {
 		Name               string

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -18,12 +18,16 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	core "k8s.io/api/core/v1"
@@ -584,6 +588,97 @@ func TestMarkDrain(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestCallOperatorAPI(t *testing.T) {
+	okServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte("body"))
+	}))
+	defer func() { okServer.Close() }()
+
+	dryRunOkServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		var evictionPayload policy.Eviction
+		err := json.NewDecoder(req.Body).Decode(&evictionPayload)
+		if err != nil {
+			res.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if evictionPayload.DeleteOptions != nil && len(evictionPayload.DeleteOptions.DryRun) == 1 && evictionPayload.DeleteOptions.DryRun[0] == "All" {
+			res.WriteHeader(http.StatusOK)
+		} else {
+			res.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		res.Write([]byte("body"))
+	}))
+	defer func() { okServer.Close() }()
+
+	internalErrorServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusInternalServerError)
+		res.Write([]byte("body"))
+	}))
+	defer func() { okServer.Close() }()
+
+	tests := []struct {
+		Name               string
+		EvictionURL        string
+		dryRun             bool
+		maxRetryOn500      int
+		expectedStatusCode int
+		expectedErr        string
+	}{
+		{
+			Name:               "Should return ok with no error",
+			EvictionURL:        okServer.URL,
+			maxRetryOn500:      5,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "Should return ok with no error if dryRun",
+			EvictionURL:        dryRunOkServer.URL,
+			maxRetryOn500:      5,
+			dryRun:             true,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "Should return 400 if not dryRun",
+			EvictionURL:        dryRunOkServer.URL,
+			maxRetryOn500:      5,
+			dryRun:             false,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErr:        "eviction endpoint error",
+		},
+		{
+			Name:               "Should return too many requests error if maxRetryOn500",
+			EvictionURL:        internalErrorServer.URL,
+			maxRetryOn500:      0,
+			dryRun:             false,
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedErr:        "eviction endpoint error: code=500 after several retries",
+		},
+		{
+			Name:               "Should return too many requests if maxRetryOn500",
+			EvictionURL:        internalErrorServer.URL,
+			maxRetryOn500:      5,
+			dryRun:             false,
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedErr:        "retry later following endpoint error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			logger := logr.Discard()
+			resp, err := CallOperatorAPI(context.Background(), logger, tt.EvictionURL, &core.Pod{ObjectMeta: meta.ObjectMeta{Name: "pod"}}, []string{}, tt.dryRun, tt.maxRetryOn500)
+
+			assert.Equal(t, tt.expectedStatusCode, resp.StatusCode)
+			if tt.expectedErr != "" {
+				assert.Contains(t, err.Error(), tt.expectedErr)
 			}
 		})
 	}

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -303,6 +303,15 @@ func GetAnnotationFromPodOrController(annotationKey string, pod *core.Pod, store
 	return "", false
 }
 
+func GetEvictionAPIURL(pod *core.Pod, store RuntimeObjectStore) (value string, found bool) {
+	evictionAPIURL, ok := GetAnnotationFromPodOrController(EvictionAPIURLAnnotationKey, pod, store)
+	if !ok {
+		// TODO: this can be removed once the deprecated annotation is no longer used
+		evictionAPIURL, ok = GetAnnotationFromPodOrController(EvictionAPIURLAnnotationKeyDeprecated, pod, store)
+	}
+	return evictionAPIURL, ok
+}
+
 // GetControllerForPod for the moment it handles only statefulSets and deployments controller
 func GetControllerForPod(pod *core.Pod, store RuntimeObjectStore) (ctrl metav1.Object, found bool) {
 	for _, r := range pod.OwnerReferences {

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -763,7 +763,7 @@ func (s *DrainoConfigurationObserverImpl) HasEvictionUrlViaAnnotation(node *v1.N
 		return false
 	}
 	for _, p := range pods {
-		if _, ok := kubernetes.GetAnnotationFromPodOrController(kubernetes.EvictionAPIURLAnnotationKey, p, s.runtimeObjectStore); ok {
+		if _, ok := kubernetes.GetEvictionAPIURL(p, s.runtimeObjectStore); ok {
 			return true
 		}
 	}


### PR DESCRIPTION
This adds support for dry-run eviction requests to custom eviction urls. Previously we would assume they pass simulation and return early. Now if a pod or its controller has the annotation `draino/eviction-api-dry-run-supported`, it will send a request to the same custom eviction url but with an extra parameter in the json payload like how we do it for kubernetes evictions https://github.com/DataDog/draino/blob/133685a72502fd717b6de1d7c1ac7ca814b78755/internal/kubernetes/drain/simulator.go#L221-L229. If the pod is not opted in, then we will continue to pass simulation early.

If the pod is opted-in, it will not perform pdb checks, this is because the eviction api url should be doing all necessary checks, and might not care about pdbs. However, we will check the rate limiter.

I tested this with my own custom eviction endpoint. I printed out the request bodies from the server side (the first request was simulation, with `dryRun:["All"]` defined, the second request was the actual eviction):
```
10.131.54.176 - - [20/Jun/2023 18:16:59] "POST / HTTP/1.1" 200 -
Request Body: {"kind":"Eviction","apiVersion":"policy/v1","metadata":{"name":"rahul-test-deployment-65b95444f9-9d5mt","namespace":"rahul-test","creationTimestamp":null,"annotations":{"draino/node-conditions":"application,nodegroup-update"}},"deleteOptions":{"dryRun":["All"]}}

10.131.54.176 - - [20/Jun/2023 18:21:36] "POST / HTTP/1.1" 200 -
Request Body: {"kind":"Eviction","apiVersion":"policy/v1","metadata":{"name":"rahul-test-deployment-65b95444f9-9d5mt","namespace":"rahul-test","creationTimestamp":null,"annotations":{"draino/node-conditions":"application,nodegroup-update"}}}
```
