### PR TITLE
Simulation metrics

### DIFF
--- a/cmd/draino/metrics.go
+++ b/cmd/draino/metrics.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/planetlabs/draino/internal/drain_runner"
+	"github.com/planetlabs/draino/internal/kubernetes/drain"
 	"github.com/planetlabs/draino/internal/metrics"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
@@ -74,6 +75,7 @@ func DrainoLegacyMetrics(ctx context.Context, options *Options, logger logr.Logg
 	groups.RegisterMetrics(promOptions.Registry)
 	observability.RegisterNewMetrics(promOptions.Registry, options.scopeAnalysisPeriod)
 	metrics.RegisterMetrics(promOptions.Registry)
+	drain.RegisterMetrics(promOptions.Registry)
 
 	if options.noLegacyNodeHandler {
 		DrainoMetrics(promOptions.Registry)

--- a/internal/kubernetes/drain/metrics.go
+++ b/internal/kubernetes/drain/metrics.go
@@ -19,7 +19,7 @@ var (
 		SimulatedNodes: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "draino_simulated_nodes_total",
 			Help: "Number of nodes simulated",
-		}, []string{kubernetes.TagResult.Name(), kubernetes.TagFailureCause.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name(), kubernetes.TagService.Name()}),
+		}, []string{kubernetes.TagResult.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name(), kubernetes.TagService.Name()}),
 		SimulatedPods: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "draino_simulated_pods_total",
 			Help: "Number of pods simulated",
@@ -45,14 +45,14 @@ const (
 	SimulationFailed    SimulationResult = "failed"
 )
 
-func CounterSimulatedNodes(node *core.Node, result SimulationResult, failureReason kubernetes.FailureCause, evictionURL bool) {
+func CounterSimulatedNodes(node *core.Node, result SimulationResult) {
 	values := kubernetes.GetNodeTagsValues(node)
 
-	tags := []string{string(result), string(failureReason), values.NgName, kubernetes.GetNodeGroupNamePrefix(values.NgName), values.NgNamespace, values.Team, values.Service}
+	tags := []string{string(result), values.NgName, kubernetes.GetNodeGroupNamePrefix(values.NgName), values.NgNamespace, values.Team, values.Service}
 	Metrics.SimulatedNodes.WithLabelValues(tags...).Add(1)
 }
 
-func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResult, failureReason kubernetes.FailureCause, evictionURL bool) {
+func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResult, failureReason string, evictionURL bool) {
 	podValues := kubernetes.GetPodTagsValues(pod)
 	nodeValues := kubernetes.GetNodeTagsValues(node)
 	team := podValues.Team
@@ -64,6 +64,6 @@ func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResul
 		service = nodeValues.Service
 	}
 
-	tags := []string{string(result), string(failureReason), pod.GetName(), nodeValues.NgName, kubernetes.GetNodeGroupNamePrefix(nodeValues.NgName), nodeValues.NgNamespace, team, service, strconv.FormatBool(evictionURL)}
+	tags := []string{string(result), failureReason, pod.GetName(), nodeValues.NgName, kubernetes.GetNodeGroupNamePrefix(nodeValues.NgName), nodeValues.NgNamespace, team, service, strconv.FormatBool(evictionURL)}
 	Metrics.SimulatedNodes.WithLabelValues(tags...).Add(1)
 }

--- a/internal/kubernetes/drain/metrics.go
+++ b/internal/kubernetes/drain/metrics.go
@@ -1,0 +1,69 @@
+package drain
+
+import (
+	"reflect"
+	"strconv"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	core "k8s.io/api/core/v1"
+
+	"github.com/planetlabs/draino/internal/kubernetes"
+)
+
+var (
+	Metrics = struct {
+		SimulatedNodes *prometheus.CounterVec
+		SimulatedPods  *prometheus.CounterVec
+	}{
+		SimulatedNodes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "draino_simulated_nodes_total",
+			Help: "Number of nodes simulated",
+		}, []string{kubernetes.TagResult.Name(), kubernetes.TagFailureCause.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name(), kubernetes.TagService.Name()}),
+		SimulatedPods: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "draino_simulated_pods_total",
+			Help: "Number of pods simulated",
+		}, []string{kubernetes.TagResult.Name(), kubernetes.TagFailureCause.Name(), kubernetes.TagPodName.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name(), kubernetes.TagService.Name(), kubernetes.TagUserEvictionURL.Name()}),
+	}
+	registerOnce sync.Once
+)
+
+func RegisterMetrics(reg prometheus.Registerer) {
+	registerOnce.Do(func() {
+		values := reflect.ValueOf(Metrics)
+		for i := 0; i < values.NumField(); i++ {
+			collector := values.Field(i).Interface().(prometheus.Collector)
+			reg.MustRegister(collector)
+		}
+	})
+}
+
+type SimulationResult string
+
+const (
+	SimulationSucceeded SimulationResult = "succeeded"
+	SimulationFailed    SimulationResult = "failed"
+)
+
+func CounterSimulatedNodes(node *core.Node, result SimulationResult, failureReason kubernetes.FailureCause, evictionURL bool) {
+	values := kubernetes.GetNodeTagsValues(node)
+
+	tags := []string{string(result), string(failureReason), values.NgName, kubernetes.GetNodeGroupNamePrefix(values.NgName), values.NgNamespace, values.Team, values.Service}
+	Metrics.SimulatedNodes.WithLabelValues(tags...).Add(1)
+}
+
+func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResult, failureReason kubernetes.FailureCause, evictionURL bool) {
+	podValues := kubernetes.GetPodTagsValues(pod)
+	nodeValues := kubernetes.GetNodeTagsValues(node)
+	team := podValues.Team
+	if team == "" {
+		team = nodeValues.Team
+	}
+	service := podValues.Service
+	if service == "" {
+		service = nodeValues.Service
+	}
+
+	tags := []string{string(result), string(failureReason), pod.GetName(), nodeValues.NgName, kubernetes.GetNodeGroupNamePrefix(nodeValues.NgName), nodeValues.NgNamespace, team, service, strconv.FormatBool(evictionURL)}
+	Metrics.SimulatedNodes.WithLabelValues(tags...).Add(1)
+}

--- a/internal/kubernetes/drain/metrics.go
+++ b/internal/kubernetes/drain/metrics.go
@@ -23,7 +23,7 @@ var (
 		SimulatedPods: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "draino_simulated_pods_total",
 			Help: "Number of pods simulated",
-		}, []string{kubernetes.TagResult.Name(), kubernetes.TagFailureCause.Name(), kubernetes.TagPodName.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name(), kubernetes.TagService.Name(), kubernetes.TagUserEvictionURL.Name()}),
+		}, []string{kubernetes.TagResult.Name(), kubernetes.TagNodegroupName.Name(), kubernetes.TagNodegroupNamePrefix.Name(), kubernetes.TagNodegroupNamespace.Name(), kubernetes.TagTeam.Name(), kubernetes.TagService.Name(), kubernetes.TagUserEvictionURL.Name()}),
 	}
 	registerOnce sync.Once
 )
@@ -52,7 +52,7 @@ func CounterSimulatedNodes(node *core.Node, result SimulationResult) {
 	Metrics.SimulatedNodes.WithLabelValues(tags...).Add(1)
 }
 
-func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResult, failureReason string, evictionURL bool) {
+func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResult, evictionURL bool) {
 	podValues := kubernetes.GetPodTagsValues(pod)
 	nodeValues := kubernetes.GetNodeTagsValues(node)
 	team := podValues.Team
@@ -64,6 +64,6 @@ func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResul
 		service = nodeValues.Service
 	}
 
-	tags := []string{string(result), failureReason, pod.GetName(), nodeValues.NgName, kubernetes.GetNodeGroupNamePrefix(nodeValues.NgName), nodeValues.NgNamespace, team, service, strconv.FormatBool(evictionURL)}
+	tags := []string{string(result), nodeValues.NgName, kubernetes.GetNodeGroupNamePrefix(nodeValues.NgName), nodeValues.NgNamespace, team, service, strconv.FormatBool(evictionURL)}
 	Metrics.SimulatedNodes.WithLabelValues(tags...).Add(1)
 }

--- a/internal/kubernetes/drain/metrics.go
+++ b/internal/kubernetes/drain/metrics.go
@@ -65,5 +65,5 @@ func CounterSimulatedPods(pod *core.Pod, node *core.Node, result SimulationResul
 	}
 
 	tags := []string{string(result), nodeValues.NgName, kubernetes.GetNodeGroupNamePrefix(nodeValues.NgName), nodeValues.NgNamespace, team, service, strconv.FormatBool(evictionURL)}
-	Metrics.SimulatedNodes.WithLabelValues(tags...).Add(1)
+	Metrics.SimulatedPods.WithLabelValues(tags...).Add(1)
 }

--- a/internal/kubernetes/drain/simulator.go
+++ b/internal/kubernetes/drain/simulator.go
@@ -136,15 +136,23 @@ func (sim *drainSimulatorImpl) SimulateDrain(ctx context.Context, node *corev1.N
 				errors = append(errors, err)
 			}
 		}
+		CounterSimulatedPods(pod, node, simResult(canEvict), reason, sim.usesOperatorAPI(pod))
 	}
 
-	// TODO add suceeded/failed node drain simulation count metric
+	CounterSimulatedNodes(node, simResult(len(reasons) > 0))
 	if len(reasons) > 0 {
 		sim.eventRecorder.NodeEventf(ctx, node, corev1.EventTypeWarning, eventDrainSimulationFailed, "Drain simulation failed: "+strings.Join(reasons, "; "))
 		return false, reasons, errors
 	}
 
 	return true, nil, errors
+}
+
+func simResult(canDrain bool) SimulationResult {
+	if canDrain {
+		return SimulationSucceeded
+	}
+	return SimulationFailed
 }
 
 func (sim *drainSimulatorImpl) nodeReasonFromPodReason(pod *corev1.Pod, reason string) string {

--- a/internal/kubernetes/drain/simulator.go
+++ b/internal/kubernetes/drain/simulator.go
@@ -128,7 +128,6 @@ func (sim *drainSimulatorImpl) SimulateDrain(ctx context.Context, node *corev1.N
 	}
 
 	for _, pod := range pods {
-		// TODO add suceeded/failed pod drain simulation count metric
 		canEvict, reason, err := sim.SimulatePodDrain(ctx, pod, node)
 		if !canEvict {
 			reasons = append(reasons, sim.nodeReasonFromPodReason(pod, reason))
@@ -136,10 +135,11 @@ func (sim *drainSimulatorImpl) SimulateDrain(ctx context.Context, node *corev1.N
 				errors = append(errors, err)
 			}
 		}
-		CounterSimulatedPods(pod, node, simResult(canEvict), reason, sim.usesOperatorAPI(pod))
+		CounterSimulatedPods(pod, node, simResult(canEvict), sim.usesOperatorAPI(pod))
 	}
 
-	CounterSimulatedNodes(node, simResult(len(reasons) > 0))
+	// 0 reasons means the simulation succeeded
+	CounterSimulatedNodes(node, simResult(len(reasons) == 0))
 	if len(reasons) > 0 {
 		sim.eventRecorder.NodeEventf(ctx, node, corev1.EventTypeWarning, eventDrainSimulationFailed, "Drain simulation failed: "+strings.Join(reasons, "; "))
 		return false, reasons, errors

--- a/internal/kubernetes/metrics.go
+++ b/internal/kubernetes/metrics.go
@@ -13,7 +13,6 @@ var (
 	MeasurePreprovisioningLatency  = stats.Float64("draino/nodes_preprovisioning_latency", "Latency to get a node preprovisioned", stats.UnitMilliseconds)
 
 	TagNodeName, _                        = tag.NewKey("node_name")
-	TagPodName, _                         = tag.NewKey("pod_name")
 	TagConditions, _                      = tag.NewKey("conditions")
 	TagTeam, _                            = tag.NewKey("team")
 	TagService, _                         = tag.NewKey("service")

--- a/internal/kubernetes/metrics.go
+++ b/internal/kubernetes/metrics.go
@@ -13,6 +13,7 @@ var (
 	MeasurePreprovisioningLatency  = stats.Float64("draino/nodes_preprovisioning_latency", "Latency to get a node preprovisioned", stats.UnitMilliseconds)
 
 	TagNodeName, _                        = tag.NewKey("node_name")
+	TagPodName, _                         = tag.NewKey("pod_name")
 	TagConditions, _                      = tag.NewKey("conditions")
 	TagTeam, _                            = tag.NewKey("team")
 	TagService, _                         = tag.NewKey("service")

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -232,6 +232,20 @@ func GetNodeTagsValues(node *core.Node) NodeTagsValues {
 	}
 }
 
+type PodTagsValues struct {
+	Team, Service string
+}
+
+func GetPodTagsValues(pod *core.Pod) PodTagsValues {
+	team := pod.Labels["team"]
+	service := pod.Labels["service"]
+
+	return PodTagsValues{
+		Team:        team,
+		Service:     service,
+	}
+}
+
 func GetNodeGroupNamePrefix(ngName string) string {
 	return strings.Split(ngName, "-")[0]
 }


### PR DESCRIPTION
Followup to https://github.com/DataDog/draino/pull/256

Inspired from https://github.com/DataDog/draino/blob/master/internal/drain_runner/metrics.go

This counts simulated pods and nodes, telling us which ones failed vs succeeded. We can also split by if a pod is using eviction++ or not