### PR TITLE
feature: sync node taint to pod condition

### DIFF
--- a/internal/drain_runner/pre_processor/pre_activities.go
+++ b/internal/drain_runner/pre_processor/pre_activities.go
@@ -64,7 +64,7 @@ func (_ *PreActivitiesPreProcessor) GetName() string {
 	return "PreActivitiesPreProcessor"
 }
 
-func preActivityStateConverter(val string) (string, error) {
+func PreActivityStateConverter(val string) (string, error) {
 	switch val {
 	case PreActivityAnnotationNotStarted, PreActivityAnnotationProcessing, PreActivityAnnotationFailed, PreActivityAnnotationDone:
 		return val, nil
@@ -148,7 +148,7 @@ type preActivity struct {
 // getActivities will search for all pre activity annotations in the whole chain (node -> pod -> controller).
 // Furthermore, it's going to evaluate the timeout annotation for the same activity
 func (pre *PreActivitiesPreProcessor) getActivities(ctx context.Context, node *corev1.Node) (map[string]*preActivity, error) {
-	activitySearch, err := kubernetes.NewSearch(ctx, pre.podIndexer, nil, pre.store, preActivityStateConverter, node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
+	activitySearch, err := kubernetes.NewSearch(ctx, pre.podIndexer, nil, pre.store, PreActivityStateConverter, node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/drain_runner/pre_processor/pre_activities_test.go
+++ b/internal/drain_runner/pre_processor/pre_activities_test.go
@@ -369,7 +369,7 @@ func TestPreActivitiesPreProcessor_Reset(t *testing.T) {
 			var node corev1.Node
 			err = wrapper.GetManagerClient().Get(ctx, types.NamespacedName{Name: tt.Node.Name}, &node)
 			assert.NoError(t, err, "Failed to refresh node")
-			result, err := kubernetes.NewSearch(ctx, idx, nil, store, preActivityStateConverter, &node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
+			result, err := kubernetes.NewSearch(ctx, idx, nil, store, PreActivityStateConverter, &node, PreActivityAnnotationPrefix, false, false, kubernetes.GetPrefixedAnnotation)
 			for _, item := range result.Results() {
 				assert.Equal(t, PreActivityAnnotationNotStarted, item.Value, "Did not properly reset pre-activity for: %v", item.Source)
 			}

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -96,9 +96,9 @@ const (
 
 	eventReasonBadValueForAnnotation = "BadValueForAnnotation"
 
-	EvictionAPIURLAnnotationKeyDeprecated   = "draino/eviction-api-url"
-	EvictionAPIURLAnnotationKey             = "node-lifecycle.datadoghq.com/eviction-api-url"
-	EvictionAPIDryRunSupportedAnnotationKey = "node-lifecycle.datadoghq.com/eviction-api-dry-run-supported"
+	EvictionAPIURLAnnotationKeyDeprecated    = "draino/eviction-api-url"
+	EvictionAPIURLAnnotationKey              = "node-lifecycle.datadoghq.com/eviction-api-url"
+	EvictionAPIDryRunSupportedAnnotationKey  = "node-lifecycle.datadoghq.com/eviction-api-dry-run-supported"
 	EvictionAPIDryRunSupportedAnnotationTrue = "true"
 )
 

--- a/internal/kubernetes/k8sclient/pod_conditions.go
+++ b/internal/kubernetes/k8sclient/pod_conditions.go
@@ -1,0 +1,87 @@
+package k8sclient
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	PodNLAConditionType    = "NodeLifecycle"
+	PodNLAConditionReason  = "NodeDrainCandidate"
+	PodNLAConditionMessage = "Node was selected as drain candidate."
+)
+
+// GetPodNLACondition will return a copy the NLA condition if found.
+// If not, it will return nil and false.
+// The function only cares about the condition type and not reason or message.
+func GetPodNLACondition(pod *corev1.Pod) (*corev1.PodCondition, bool) {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == PodNLAConditionType {
+			return condition.DeepCopy(), true
+		}
+	}
+
+	return nil, false
+}
+
+// SetOrUpdatePodNLACondition will create the NLA condition on the given Pod. In case it exists already, it will update LastProbeTime to the given TS.
+// As a result, it will return the new Pod, with the updated condition.
+func SetOrUpdatePodNLACondition(ctx context.Context, kubeClient client.Client, pod *corev1.Pod, ts time.Time) (*corev1.Pod, error) {
+	newPod := pod.DeepCopy()
+
+	idx := -1
+	for i, condition := range newPod.Status.Conditions {
+		if condition.Type == PodNLAConditionType {
+			idx = i
+		}
+	}
+
+	if idx >= 0 {
+		newPod.Status.Conditions[idx].LastProbeTime = metav1.NewTime(ts)
+	} else {
+		newPod.Status.Conditions = append(newPod.Status.Conditions, corev1.PodCondition{
+			Type:               PodNLAConditionType,
+			Status:             corev1.ConditionTrue,
+			LastProbeTime:      metav1.NewTime(ts),
+			LastTransitionTime: metav1.NewTime(ts),
+			Reason:             PodNLAConditionReason,
+			Message:            PodNLAConditionMessage,
+		})
+	}
+
+	// The strategic merge path will only update the specific condition
+	err := kubeClient.SubResource("status").Patch(ctx, newPod, client.StrategicMergeFrom(pod))
+	if err != nil {
+		return nil, err
+	}
+
+	return newPod, nil
+}
+
+// RemovePodNLACondition will remove the NLA condition from the given pod, if it has it.
+func RemovePodNLACondition(ctx context.Context, kubeClient client.Client, pod *corev1.Pod) (*corev1.Pod, bool, error) {
+	if _, exists := GetPodNLACondition(pod); !exists {
+		return pod, false, nil
+	}
+
+	newPod := pod.DeepCopy()
+	newConditions := make([]corev1.PodCondition, 0, (len(newPod.Status.Conditions)))
+	for _, condition := range newPod.Status.Conditions {
+		if condition.Type != PodNLAConditionType {
+			newConditions = append(newConditions, condition)
+		}
+	}
+
+	newPod.Status.Conditions = newConditions
+	// The strategic merge path will only update the specific condition
+	err := kubeClient.SubResource("status").Patch(ctx, newPod, client.StrategicMergeFrom(pod))
+	if err != nil {
+		return nil, false, err
+	}
+
+	return newPod, true, nil
+}

--- a/internal/kubernetes/k8sclient/pod_conditions_test.go
+++ b/internal/kubernetes/k8sclient/pod_conditions_test.go
@@ -1,0 +1,196 @@
+package k8sclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetPodNLACondition(t *testing.T) {
+	tests := []struct {
+		Name            string
+		Pod             *corev1.Pod
+		ExpectCondition bool
+	}{
+		{
+			Name:            "Should find condition",
+			Pod:             createPodWithCondition(true, time.Now()),
+			ExpectCondition: true,
+		},
+		{
+			Name:            "Should not find condition",
+			Pod:             createPodWithCondition(false, time.Now()),
+			ExpectCondition: false,
+		},
+		{
+			Name: "Should not find condition with same reason",
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test",
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:          "OtherType",
+							Status:        corev1.ConditionTrue,
+							Reason:        PodNLAConditionReason,
+							Message:       PodNLAConditionMessage,
+							LastProbeTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			ExpectCondition: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			_, exists := GetPodNLACondition(tt.Pod)
+			assert.Equal(t, tt.ExpectCondition, exists)
+		})
+	}
+}
+
+func TestSetOrUpdatePodNLACondition(t *testing.T) {
+	tests := []struct {
+		Name               string
+		Pod                *corev1.Pod
+		TS                 time.Time
+		ExpectNewCondition bool
+	}{
+		{
+			Name:               "Should set condition if not there yet",
+			Pod:                createPodWithCondition(false, time.Now()),
+			TS:                 time.Now(),
+			ExpectNewCondition: true,
+		},
+		{
+			Name:               "Should update condition probe time",
+			Pod:                createPodWithCondition(true, time.Now().Add(-time.Minute)),
+			TS:                 time.Now(),
+			ExpectNewCondition: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.Pod).Build()
+
+			newPod, err := SetOrUpdatePodNLACondition(context.Background(), fakeClient, tt.Pod, tt.TS)
+			assert.NoError(t, err, "failed to set pod condition")
+			assert.NotEqual(t, tt.Pod, newPod, "should not be same pointer")
+
+			var freshPod corev1.Pod
+			err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: tt.Pod.Namespace, Name: tt.Pod.Name}, &freshPod)
+			assert.NoError(t, err, "failed to get fresh pod")
+
+			condition, exists := GetPodNLACondition(&freshPod)
+			assert.True(t, exists, "should have condition set")
+			// We have to format it, because the kubernetes object TS is losing some precision
+			assert.Equal(t, tt.TS.Format(time.RFC3339), condition.LastProbeTime.Format(time.RFC3339), "should always update last probe time")
+
+			if tt.ExpectNewCondition {
+				// We have to format it, because the kubernetes object TS is losing some precision
+				assert.Equal(t, tt.TS.Format(time.RFC3339), condition.LastTransitionTime.Time.Format(time.RFC3339))
+				// Make sure that we add a new condition and don't overwrite another one
+				assert.Equal(t, (len(tt.Pod.Status.Conditions) + 1), len(freshPod.Status.Conditions))
+			} else {
+				// We have to format it, because the kubernetes object TS is losing some precision
+				assert.NotEqual(t, tt.TS.Format(time.RFC3339), condition.LastTransitionTime.Time.Format(time.RFC3339))
+				// Make sure we don't create a new condition
+				assert.Equal(t, len(tt.Pod.Status.Conditions), len(freshPod.Status.Conditions))
+			}
+		})
+	}
+}
+
+func TestRemovePodNLACondition(t *testing.T) {
+	tests := []struct {
+		Name            string
+		Pod             *corev1.Pod
+		ExpectedRemoved bool
+		ExpectedNewPod  bool
+	}{
+		{
+			Name:            "Should remove condition from pod",
+			Pod:             createPodWithCondition(true, time.Now()),
+			ExpectedRemoved: true,
+			ExpectedNewPod:  true,
+		},
+		{
+			Name:            "Should not do anything if pod doesn't have condition",
+			Pod:             createPodWithCondition(false, time.Now()),
+			ExpectedRemoved: false,
+			ExpectedNewPod:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.Pod).Build()
+
+			newPod, removed, err := RemovePodNLACondition(context.Background(), fakeClient, tt.Pod)
+			assert.NoError(t, err, "failed to set pod condition")
+			assert.Equal(t, tt.ExpectedRemoved, removed)
+
+			if tt.ExpectedNewPod {
+				assert.NotEqual(t, tt.Pod, newPod, "should not be same pointer")
+			} else {
+				assert.Equal(t, tt.Pod, newPod, "should not be same pointer")
+			}
+
+			var freshPod corev1.Pod
+			err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: tt.Pod.Namespace, Name: tt.Pod.Name}, &freshPod)
+			assert.NoError(t, err, "failed to get fresh pod")
+
+			condition, exists := GetPodNLACondition(&freshPod)
+			assert.Nil(t, condition, "should not find any condition")
+			assert.False(t, exists, "should not have condition set")
+
+			// Make sure that only our condition was removed
+			if tt.ExpectedRemoved {
+				assert.Equal(t, (len(tt.Pod.Status.Conditions) - 1), len(freshPod.Status.Conditions))
+			} else {
+				assert.Equal(t, len(tt.Pod.Status.Conditions), len(freshPod.Status.Conditions))
+			}
+		})
+	}
+}
+
+func createPodWithCondition(hasNLACondition bool, time time.Time) *corev1.Pod {
+	conditions := []corev1.PodCondition{
+		{
+			Type:               "RandomCondition",
+			Status:             corev1.ConditionFalse,
+			LastProbeTime:      metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	if hasNLACondition {
+		conditions = append(conditions, corev1.PodCondition{
+			Type:               PodNLAConditionType,
+			Status:             corev1.ConditionTrue,
+			Reason:             PodNLAConditionReason,
+			Message:            PodNLAConditionMessage,
+			LastProbeTime:      metav1.NewTime(time),
+			LastTransitionTime: metav1.NewTime(time),
+		})
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test",
+		},
+		Status: corev1.PodStatus{
+			Conditions: conditions,
+		},
+	}
+}

--- a/internal/kubernetes/util.go
+++ b/internal/kubernetes/util.go
@@ -241,8 +241,8 @@ func GetPodTagsValues(pod *core.Pod) PodTagsValues {
 	service := pod.Labels["service"]
 
 	return PodTagsValues{
-		Team:        team,
-		Service:     service,
+		Team:    team,
+		Service: service,
 	}
 }
 

--- a/internal/sync/nla_taint_sync.go
+++ b/internal/sync/nla_taint_sync.go
@@ -1,0 +1,95 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/compute-go/logs"
+	"github.com/go-logr/logr"
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NLATaintSynchronizer interface {
+	// SyncNodeTaintToPods will sync the NLA taint to all pods of the given node
+	SyncNodeTaintToPods(context.Context, *corev1.Node) error
+}
+
+type taintSynchronizerImpl struct {
+	kubeClient    client.Client
+	logger        logr.Logger
+	clock         clock.Clock
+	podIndexer    index.PodIndexer
+	podFilterFunc kubernetes.PodFilterFunc
+}
+
+func NewNLATaintSynchronizer(kubeClient client.Client, logger logr.Logger, clock clock.Clock, podIndexer index.PodIndexer, podFilterFunc kubernetes.PodFilterFunc) NLATaintSynchronizer {
+	return &taintSynchronizerImpl{
+		kubeClient:    kubeClient,
+		logger:        logger.WithName("NLATaintSynchronizaer"),
+		clock:         clock,
+		podIndexer:    podIndexer,
+		podFilterFunc: podFilterFunc,
+	}
+}
+
+func (t *taintSynchronizerImpl) SyncNodeTaintToPods(ctx context.Context, node *corev1.Node) error {
+	_, taintExists := k8sclient.GetNLATaint(node)
+	t.logger.V(logs.ZapDebug).Info("received node with taint", "node", node.Name, "taint_exists", taintExists)
+
+	pods, err := t.podIndexer.GetPodsByNode(ctx, node.Name)
+	if err != nil {
+		return err
+	}
+
+	var compoundErrors []string
+	t.logger.V(logs.ZapDebug).Info("found ... pods to sync", "node", node.Name, "pod_count", pods)
+
+	for _, pod := range pods {
+		pass, _, err := t.podFilterFunc(*pod)
+		if err != nil {
+			t.logger.Error(err, "failed to filter pod", "node", node.Name, "pod", pod.Name, "pod_namespace", pod.Namespace, "should_have_condition", taintExists)
+			compoundErrors = append(compoundErrors, err.Error())
+			continue
+		}
+		if !pass {
+			continue
+		}
+		if err := t.syncPodCondition(ctx, pod, taintExists); err != nil {
+			t.logger.Error(err, "failed to sync pod condition", "node", node.Name, "pod", pod.Name, "pod_namespace", pod.Namespace, "should_have_condition", taintExists)
+			compoundErrors = append(compoundErrors, err.Error())
+		}
+	}
+
+	if len(compoundErrors) > 0 {
+		return fmt.Errorf("failed to sync taint to pods: %s", strings.Join(compoundErrors, ";"))
+	}
+	return nil
+}
+
+func (t *taintSynchronizerImpl) syncPodCondition(ctx context.Context, pod *corev1.Pod, shouldHaveCondition bool) error {
+	_, exists := k8sclient.GetPodNLACondition(pod)
+	logger := t.logger.WithValues("node", pod.Spec.NodeName, "pod", pod.Name, "pod_namespace", pod.Namespace, "should_have_condition", shouldHaveCondition, "has_condition", exists)
+
+	logger.V(logs.ZapDebug).Info("received pod with condition")
+	if exists == shouldHaveCondition {
+		logger.V(logs.ZapDebug).Info("expected condition is matching NLA taint")
+		return nil
+	}
+
+	var err error
+	if shouldHaveCondition {
+		logger.V(logs.ZapDebug).Info("adding condition to pod")
+		_, err = k8sclient.SetOrUpdatePodNLACondition(ctx, t.kubeClient, pod, t.clock.Now())
+	} else {
+		logger.V(logs.ZapDebug).Info("removing condition from pod")
+		_, _, err = k8sclient.RemovePodNLACondition(ctx, t.kubeClient, pod)
+	}
+
+	return err
+}

--- a/internal/sync/nla_taint_sync_test.go
+++ b/internal/sync/nla_taint_sync_test.go
@@ -1,0 +1,213 @@
+package sync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/planetlabs/draino/internal/kubernetes"
+	"github.com/planetlabs/draino/internal/kubernetes/index"
+	"github.com/planetlabs/draino/internal/kubernetes/k8sclient"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/taints"
+	"k8s.io/utils/clock"
+)
+
+func TestSyncNodeTaintToPods(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Node          *corev1.Node
+		Pods          []runtime.Object
+		PodFilterFunc kubernetes.PodFilterFunc
+
+		ExpectedPodWithConditionCount int
+	}{
+		{
+			Name: "Should set pod conditions",
+			Node: createTestNode(t, "foo-node", true),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", false),
+				createPodWithCondition("test-pod2", "test", "foo-node", false),
+			},
+			PodFilterFunc:                 filterAlwaysReturn,
+			ExpectedPodWithConditionCount: 2,
+		},
+		{
+			Name: "Should set pod conditions, no matter which pod namespace",
+			Node: createTestNode(t, "foo-node", true),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", false),
+				createPodWithCondition("test-pod2", "other-ns", "foo-node", false),
+			},
+			PodFilterFunc:                 filterAlwaysReturn,
+			ExpectedPodWithConditionCount: 2,
+		},
+		{
+			Name: "Should not touch pods on other nodes",
+			Node: createTestNode(t, "foo-node", true),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", false),
+				createPodWithCondition("test-pod2", "test", "second-node", false),
+			},
+			PodFilterFunc:                 filterAlwaysReturn,
+			ExpectedPodWithConditionCount: 1,
+		},
+		{
+			Name: "Should ignore pods that are not returned by the discovery func",
+			Node: createTestNode(t, "foo-node", true),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", false),
+				createPodWithCondition("test-pod2", "test", "foo-node", false),
+			},
+			PodFilterFunc:                 discoveryFuncThatIgnoresPodsWithName("test-pod"),
+			ExpectedPodWithConditionCount: 1,
+		},
+		{
+			Name:                          "Should not fail if there are no pods",
+			Node:                          createTestNode(t, "foo-node", true),
+			Pods:                          []runtime.Object{},
+			PodFilterFunc:                 discoveryFuncThatIgnoresPodsWithName("test-pod"),
+			ExpectedPodWithConditionCount: 0,
+		},
+		{
+			Name: "Should remove conditions if taint got removed",
+			Node: createTestNode(t, "foo-node", false),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", true),
+				createPodWithCondition("test-pod2", "test", "foo-node", true),
+			},
+			PodFilterFunc:                 filterAlwaysReturn,
+			ExpectedPodWithConditionCount: 0,
+		},
+		{
+			Name: "Should remove condition from pods of other namespace",
+			Node: createTestNode(t, "foo-node", false),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", true),
+				createPodWithCondition("test-pod2", "other-ns", "foo-node", true),
+			},
+			PodFilterFunc:                 filterAlwaysReturn,
+			ExpectedPodWithConditionCount: 0,
+		},
+		{
+			Name: "Should not fail if there is no condition to be removed",
+			Node: createTestNode(t, "foo-node", false),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", false),
+				createPodWithCondition("test-pod2", "test", "foo-node", true),
+			},
+			PodFilterFunc:                 filterAlwaysReturn,
+			ExpectedPodWithConditionCount: 0,
+		},
+		{
+			Name: "Should only remove the condition from the actual node",
+			Node: createTestNode(t, "foo-node", false),
+			Pods: []runtime.Object{
+				createPodWithCondition("test-pod", "test", "foo-node", true),
+				createPodWithCondition("test-pod2", "test", "second-node", true),
+			},
+			PodFilterFunc:                 filterAlwaysReturn,
+			ExpectedPodWithConditionCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			wrapper, err := k8sclient.NewFakeClient(k8sclient.FakeConf{Objects: append(tt.Pods, tt.Node)})
+			assert.NoError(t, err)
+
+			ctx, cancelFn := context.WithCancel(context.Background())
+			defer cancelFn()
+			fakeIndexer, err := index.New(ctx, wrapper.GetManagerClient(), wrapper.GetCache(), logr.Discard())
+			assert.NoError(t, err)
+
+			ch := make(chan struct{})
+			defer close(ch)
+			wrapper.Start(ch)
+
+			synchronizer := NewNLATaintSynchronizer(wrapper.GetManagerClient(), logr.Discard(), clock.RealClock{}, fakeIndexer, tt.PodFilterFunc)
+			err = synchronizer.SyncNodeTaintToPods(context.Background(), tt.Node)
+			assert.NoError(t, err, "failed to sync node taint to pods")
+
+			var podList corev1.PodList
+			err = wrapper.GetManagerClient().List(context.Background(), &podList)
+			assert.NoError(t, err, "failed to get pods for node")
+
+			var podWithConditionConter int
+			for _, pod := range podList.Items {
+				if _, exists := k8sclient.GetPodNLACondition(&pod); exists {
+					podWithConditionConter += 1
+				}
+			}
+
+			assert.Equal(t, tt.ExpectedPodWithConditionCount, podWithConditionConter)
+		})
+	}
+}
+
+func discoveryFuncThatIgnoresPodsWithName(name string) kubernetes.PodFilterFunc {
+	return func(p corev1.Pod) (pass bool, reason string, err error) {
+		if p.Name == name {
+			return false, "name_does_not_match", nil
+		}
+		return true, "", nil
+	}
+}
+
+func filterAlwaysReturn(p corev1.Pod) (pass bool, reason string, err error) {
+	return true, "", nil
+}
+
+func createTestNode(t *testing.T, name string, withNLATaint bool) *corev1.Node {
+	var err error
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if withNLATaint {
+		node, _, err = taints.AddOrUpdateTaint(node, k8sclient.CreateNLATaint(k8sclient.TaintDrainCandidate, time.Now()))
+		assert.NoError(t, err, "failed to add NLA taint to test node")
+
+	}
+
+	return node
+}
+
+func createPodWithCondition(name, ns, nodeName string, hasNLACondition bool) *corev1.Pod {
+	conditions := []corev1.PodCondition{
+		{
+			Type:               "RandomCondition",
+			Status:             corev1.ConditionFalse,
+			LastProbeTime:      metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	if hasNLACondition {
+		conditions = append(conditions, corev1.PodCondition{
+			Type:               k8sclient.PodNLAConditionType,
+			Status:             corev1.ConditionTrue,
+			Reason:             k8sclient.PodNLAConditionReason,
+			Message:            k8sclient.PodNLAConditionMessage,
+			LastProbeTime:      metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+		Status: corev1.PodStatus{
+			Conditions: conditions,
+		},
+	}
+}

--- a/internal/sync/reconciler.go
+++ b/internal/sync/reconciler.go
@@ -1,0 +1,84 @@
+package sync
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/planetlabs/draino/internal/drain_runner/pre_processor"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type NodeTaintSyncReconciler struct {
+	kubeClient    client.Client
+	synchonizator NLATaintSynchronizer
+	logger        logr.Logger
+}
+
+func NewNodeTaintSyncReconciler(kubeClient client.Client, sync NLATaintSynchronizer, logger logr.Logger) *NodeTaintSyncReconciler {
+	return &NodeTaintSyncReconciler{
+		kubeClient:    kubeClient,
+		synchonizator: sync,
+		logger:        logger.WithName("NodeTaintSyncReconciler"),
+	}
+}
+
+func (n *NodeTaintSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var node corev1.Node
+	err := n.kubeClient.Get(ctx, types.NamespacedName{Name: req.Name}, &node)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := n.synchonizator.SyncNodeTaintToPods(ctx, &node); err != nil {
+		n.logger.Error(err, "failed to sync NLA taint to pods", "node", node.Name)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func MapPodToNodeName(obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	// Pod has not been scheduled yet, so we'll wait for the next update
+	if pod.Spec.NodeName == "" {
+		return nil
+	}
+
+	for key := range pod.Annotations {
+		// For now we only care about the pods that are running pre-activities
+		if strings.HasPrefix(key, pre_processor.PreActivityAnnotationPrefix) {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: pod.Spec.NodeName}},
+			}
+		}
+	}
+
+	return nil
+}
+
+func (n *NodeTaintSyncReconciler) SetupWithManager(mgr manager.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 2}).
+		For(&corev1.Node{}).
+		Watches(
+			&source.Kind{Type: &corev1.Pod{}},
+			handler.EnqueueRequestsFromMapFunc(MapPodToNodeName),
+		).
+		Complete(n)
+}


### PR DESCRIPTION
For pre-activities, our users might only care about specific pod annotations. In our current setup, they would have to watch for node updates, check if the taint was added, then figure out if the node is hosting a pod they care about, and finally trigger the update mechanism. This makes the whole process much more complex than expected.

Therefore, we've decided to create a new condition on all pods that have pre-activities assigned. This condition should always be in sync with the NLA node taint, so that the operators can react properly.